### PR TITLE
fix: use `longhorn-retain` storageClass for Grafana

### DIFF
--- a/charts/monitoring/prometheus-operator/values.yaml
+++ b/charts/monitoring/prometheus-operator/values.yaml
@@ -40,6 +40,7 @@ grafana:
   persistence:
     enabled: true
     size: 5Gi
+    storageClassName: "longhorn-retain"
 
 alertmanager:
   ingress:


### PR DESCRIPTION
### Summary

Using a retain based storage class so that the volume claim is not deleted when prometheus-operator is uninstalled.