### PR TITLE
fix: stakater/reloader not installing

### DIFF
--- a/charts/system/reloader/helmfile.yaml
+++ b/charts/system/reloader/helmfile.yaml
@@ -4,7 +4,7 @@ repositories:
 
 releases:
   - name: reloader
-    version: 1.0.71
+    version: 2.0.0
     atomic: true
     namespace: kube-system
     chart: stakater/reloader

--- a/charts/system/reloader/values.yaml
+++ b/charts/system/reloader/values.yaml
@@ -1,2 +1,9 @@
+image:
+  name: stakater/reloader
+  repository: stakater/reloader
+
 reloader:
   reloadOnCreate: true
+
+serviceMonitor:
+  enabled: true


### PR DESCRIPTION
### Summary

Use image from docker hub https://hub.docker.com/r/stakater/reloader