### PR TITLE
chore: remove deprecated traefik-crds release

### DIFF
--- a/charts/system/traefik/helmfile.yaml
+++ b/charts/system/traefik/helmfile.yaml
@@ -3,12 +3,6 @@ repositories:
     url: https://helm.traefik.io/traefik
 
 releases:
-  - name: traefik-crds
-    version: 1.14.0
-    atomic: true
-    namespace: kube-system
-    chart: traefik/traefik-crds
-
   - name: traefik
     version: 39.0.0
     atomic: true


### PR DESCRIPTION
## Description
This PR removes the deprecated `traefik-crds` release from the Traefik helmfile. 

The main `traefik` chart (v39.0.0+) now handles CRD management automatically. Having both releases caused ownership conflicts and prevented successful deployment.

## References
- Confirmed that `traefik-crds` is deprecated in favor of the main chart.
- Resolved installation failures by letting the main `traefik` chart take ownership of all necessary CRDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Traefik deployment configuration by removing CRD management from the Helm release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->