### PR TITLE
refactor: use HTML comment markers for auto-generated apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ This repository reflects a personal homelab setup. Domains, host paths, and secr
 
 ## Apps
 
+<!-- apps:start -->
+
 ### Automation
 
 | Chart                                    | Description                                                 | Source Code                            |
@@ -140,6 +142,8 @@ This repository reflects a personal homelab setup. Domains, host paths, and secr
 | [rancher](charts/system/rancher)                       | Container management platform                                             | https://github.com/rancher/rancher           |
 | [reloader](charts/system/reloader)                     | K8s controller to that does rolling upgrades on ConfigMap/Secrets changes | https://github.com/stakater/Reloader         |
 | [traefik](charts/system/traefik)                       | HTTP reverse proxy and load balancer                                      | https://github.com/traefik/traefik           |
+
+<!-- apps:end -->
 
 ---
 

--- a/packages/docs/src/lib/insertMarkdown.ts
+++ b/packages/docs/src/lib/insertMarkdown.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile } from "fs/promises";
 
-const start = "## Apps\n\n";
-const end = "\n\n---\n\n## References";
+const start = "<!-- apps:start -->\n\n";
+const end = "\n\n<!-- apps:end -->";
 const placeholder = "___placeholder___";
 const contentPattern = new RegExp(`${start}([\\S\\s]*)${end}`, "m");
 


### PR DESCRIPTION
## Summary

- Replaces the implicit heading/separator text boundaries (`## Apps` / `---\n\n## References`) with explicit `<!-- apps:start -->` / `<!-- apps:end -->` HTML comment markers
- Updates both `packages/docs/src/lib/insertMarkdown.ts` and `README.md`

Anyone reading the raw markdown now immediately sees which section is auto-generated and won't accidentally edit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)