### PR TITLE
fix(cli): resolve TypeScript errors in constants.ts

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -67,7 +67,7 @@ export const SECTIONS = {
   details: {},
 } as const;
 
-export const ACTIONS = {
+export const ACTIONS: Record<string, Action> = {
   apply: {
     label: "Apply",
     description: "Run helmfile apply for this service",
@@ -115,4 +115,4 @@ export const ACTIONS = {
     description: "Show logs for this service",
     shortcut: ["l", "L"],
   },
-} as const satisfies Record<string, Action>;
+} as const;


### PR DESCRIPTION
## Summary

Fixes typecheck errors in `packages/cli/src/constants.ts` that caused `tsc --noEmit` to fail.