### PR TITLE
fix(infisical): add secretType Opaque to managed kube secret references

### DIFF
--- a/charts/monitoring/grafana-backup/config/infisical-grafana-backup-secret.yaml
+++ b/charts/monitoring/grafana-backup/config/infisical-grafana-backup-secret.yaml
@@ -19,5 +19,6 @@ spec:
     - secretName: infisical-grafana-backup-secret
       secretNamespace: monitoring
       creationPolicy: "Owner"
+      secretType: Opaque
       template:
         includeAllSecrets: true

--- a/charts/monitoring/scraparr/config/infisical-scraparr-secret.yaml
+++ b/charts/monitoring/scraparr/config/infisical-scraparr-secret.yaml
@@ -19,5 +19,6 @@ spec:
     - secretName: infisical-scraparr-secret
       secretNamespace: monitoring
       creationPolicy: "Owner"
+      secretType: Opaque
       template:
         includeAllSecrets: true

--- a/charts/monitoring/wakatime-exporter/config/infisical-wakatime-secret.yaml
+++ b/charts/monitoring/wakatime-exporter/config/infisical-wakatime-secret.yaml
@@ -19,5 +19,6 @@ spec:
     - secretName: infisical-wakatime-secret
       secretNamespace: monitoring
       creationPolicy: "Owner"
+      secretType: Opaque
       template:
         includeAllSecrets: true

--- a/charts/system/traefik/config/infisical-traefik-secret.yaml
+++ b/charts/system/traefik/config/infisical-traefik-secret.yaml
@@ -19,5 +19,6 @@ spec:
     - secretName: infisical-traefik-secret
       secretNamespace: kube-system
       creationPolicy: "Owner"
+      secretType: Opaque
       template:
         includeAllSecrets: true


### PR DESCRIPTION
## Summary
- Adds `secretType: Opaque` to `managedKubeSecretReferences` in all 4 InfisicalSecret configs (traefik, scraparr, wakatime-exporter, grafana-backup)

## Test plan
- [ ] Verify InfisicalSecret resources sync correctly in the cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes secret configurations across monitoring and system components to explicitly specify secret types for improved configuration clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->