### PR TITLE
fix(openclaw,metallb): correct PVC name and ignore caBundle diff

### DIFF
--- a/charts/automation/openclaw/config/pv.yaml
+++ b/charts/automation/openclaw/config/pv.yaml
@@ -9,7 +9,7 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   claimRef:
-    name: openclaw
+    name: openclaw-data-pvc
     namespace: default
   hostPath:
     path: /var/local/openclaw

--- a/charts/system/metallb/application.yaml
+++ b/charts/system/metallb/application.yaml
@@ -25,6 +25,11 @@ spec:
     server: https://kubernetes.default.svc
     namespace: metallb-system
   revisionHistoryLimit: 3
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jsonPointers:
+        - /spec/conversion/webhook/clientConfig/caBundle
   syncPolicy:
     syncOptions:
       - CreateNamespace=true


### PR DESCRIPTION
## Summary
- **openclaw**: rename `claimRef.name` in `pv.yaml` from `openclaw` to `openclaw-data-pvc` to match the `existingClaim` in `values.yaml`
- **metallb**: add `ignoreDifferences` on `CustomResourceDefinition` for `caBundle` in the conversion webhook, fixing the constant out-of-sync in ArgoCD

## Test plan
- [ ] ArgoCD metallb app shows Synced (no more caBundle drift)
- [ ] After PV/PVC recreation, openclaw app shows Healthy with correct PVC binding to `openclaw-data-pvc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated persistent volume claim reference configuration
  * Enhanced deployment synchronization with server-side apply and advanced difference handling capabilities for system components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->