### PR TITLE
docs: improve README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # Selfhosted
 
-A collection of Helm charts for self-hosted services running on [Talos Linux](https://www.talos.dev/) Kubernetes, managed with [ArgoCD](https://argo-cd.readthedocs.io/).
+Run your own media server, backups, monitoring, automation, and more — on hardware you control. This repository contains a collection of Helm charts for self-hosted services, deployable on any Kubernetes cluster via [Helm](https://helm.sh/) or [ArgoCD](https://argo-cd.readthedocs.io/).
 
-> **Personal Setup:** This repository reflects a personal homelab setup. Domains, host paths, and secret names are all specific to this environment. If you're adapting it for your own use, expect to update `values.yaml` in each chart you deploy.
+> [!NOTE]
+> **Personal Setup:** This repository reflects a personal homelab setup. Domains, host paths, and secret names are specific to this environment. If you're adapting it for your own use, update the `values.yaml` in each chart you deploy.
 
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)
 - [Getting Started](#getting-started)
-  - [1. Bootstrap Talos cluster](#1-bootstrap-talos-cluster)
+  - [1. Set up a Kubernetes cluster](#1-set-up-a-kubernetes-cluster)
   - [2. Clone this repo](#2-clone-this-repo)
   - [3. Bootstrap ArgoCD (optional)](#3-bootstrap-argocd-optional)
   - [4. Deploy a service](#4-deploy-a-service)
+- [How It Works](#how-it-works)
 - [Deploy Order](#deploy-order)
 - [Host Directories](#host-directories)
 - [Secrets](#secrets)
@@ -26,22 +28,29 @@ A collection of Helm charts for self-hosted services running on [Talos Linux](ht
   - [Media](#media)
   - [Monitoring](#monitoring)
   - [System](#system)
+- [Troubleshooting](#troubleshooting)
 - [References](#references)
 - [Contributing](#contributing)
 
 ## Prerequisites
 
-- [Talos Linux](https://www.talos.dev/) — immutable Kubernetes-focused OS
+- A Kubernetes cluster (any distribution — [Talos](https://www.talos.dev/), [k3s](https://k3s.io/), etc.)
 - [Helm](https://helm.sh/docs/intro/install/) — Kubernetes package manager
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) — Kubernetes CLI
-- [ArgoCD](https://argo-cd.readthedocs.io/en/stable/getting_started/) — GitOps controller (optional, see [charts/system/argocd](charts/system/argocd))
+- [ArgoCD](https://argo-cd.readthedocs.io/en/stable/getting_started/) — optional GitOps controller (see [charts/system/argocd](charts/system/argocd))
 - [Node.js](https://nodejs.org/) + npm — optional, for the interactive CLI
 
 ## Getting Started
 
-### 1. Bootstrap Talos cluster
+### 1. Set up a Kubernetes cluster
 
-Provision your Talos control-plane and worker nodes, then export a working kubeconfig for this cluster.
+Bring up any Kubernetes cluster and export a working kubeconfig. If this is your first cluster, [k3s](https://k3s.io/) is the easiest way to start:
+
+```shell
+curl -sfL https://get.k3s.io | sh -
+```
+
+[Talos](https://www.talos.dev/), kind, and other distributions work just as well.
 
 ### 2. Clone this repo
 
@@ -52,11 +61,31 @@ cd selfhosted
 
 ### 3. Bootstrap ArgoCD (optional)
 
-See [charts/system/argocd](charts/system/argocd) for bootstrap instructions.
+ArgoCD watches this Git repo and automatically syncs changes to your cluster — no manual `helm install` needed. It also provides a web UI to monitor and manage all your deployments. See [charts/system/argocd](charts/system/argocd) for bootstrap instructions.
 
 ### 4. Deploy a service
 
-Navigate to any chart directory and follow the instructions in its `README.md`. See [Deploying a Chart](#deploying-a-chart) for details.
+Pick a chart and follow its `README.md` — each one includes instructions for both ArgoCD and plain Helm deployment. For example, to deploy [Syncthing](charts/backup/syncthing):
+
+```shell
+# With ArgoCD
+kubectl apply -f charts/backup/syncthing/application.yaml
+
+# Or with Helm directly
+helm install syncthing charts/backup/syncthing
+```
+
+See [Deploying a Chart](#deploying-a-chart) for more details.
+
+## How It Works
+
+```
+Git push → ArgoCD detects changes → Helm chart deployed → Traefik routes traffic → Service accessible
+```
+
+Each service is packaged as a Helm chart. ArgoCD watches this repo and keeps your cluster in sync with it automatically. Traefik acts as the reverse proxy, routing incoming requests to the right service based on domain/path rules. Infisical injects secrets into pods at deploy time.
+
+If you're not using ArgoCD, you can deploy any chart directly with `helm install` — the charts work the same either way.
 
 ## Deploy Order
 
@@ -70,10 +99,14 @@ System charts must be synced before any app charts. ArgoCD sync-wave annotations
 
 ## Host Directories
 
-Charts use host-mounted volumes for persistent data. The paths are defined in each chart's `config/pv.yaml` and must exist on the host before deploying. Common ones:
+Charts use host-mounted volumes for persistent data. The paths are defined in each chart's `config/pv.yaml` and must exist on the host before deploying.
+
+The defaults below reflect this homelab's setup — update them to match your own environment:
 
 - `/var/local/<service>` — per-service config and database (hostPath on the node)
-- `/mnt/nebula` — media library (movies, TV shows, downloads), mounted via NFS from `192.168.50.7:/mnt/nebula`
+- `/mnt/nebula` — media library (movies, TV shows, downloads), mounted via NFS
+
+To customize paths, edit the `config/pv.yaml` in each chart you deploy.
 
 A custom `StorageClass` with a `Retain` reclaim policy is also available to prevent data loss when PVCs are deleted — see [local-path-retain](charts/system/local-path-retain).
 
@@ -81,15 +114,21 @@ A custom `StorageClass` with a `Retain` reclaim policy is also available to prev
 
 Secrets are managed via [Infisical](https://infisical.com/) using the [infisical-operator](charts/system/infisical-operator). Each chart's `README.md` lists the required secrets and the Infisical secret name they are sourced from.
 
+If you don't use Infisical, you can create Kubernetes Secrets manually — just make sure the Secret names and keys match what each chart's templates expect.
+
 ## Deploying a Chart
 
-Deploying a chart is usually just:
+Before deploying any chart, review its `values.yaml` and update domains, paths, and other environment-specific values to match your setup. Some charts contain hardcoded domains (e.g. `jellyfin.hobroker.me`) that must be changed.
+
+Each chart's `README.md` includes instructions for both **ArgoCD** and **plain Helm** deployment, along with any extra steps required (secrets, host volumes, config files).
+
+**Quick start with ArgoCD:**
 
 ```sh
 kubectl apply -f charts/<category>/<name>/application.yaml
 ```
 
-Then sync it in the ArgoCD UI. Some charts contain a hardcoded domain (e.g. `jellyfin.hobroker.me`) — update it to your own domain before deploying. Some charts also require extra steps (config files, secrets, host volumes) — check the chart's `README.md` for details.
+Then sync it in the ArgoCD UI or with `argocd app sync <name>`.
 
 ## Interactive CLI (optional)
 
@@ -182,8 +221,18 @@ npm run generate
 
 ---
 
+## Troubleshooting
+
+- **Pod stuck in `Pending`** — check that the PersistentVolume exists and the host directory has been created (`kubectl describe pod <name>` will show the exact error)
+- **ArgoCD sync failed** — run `argocd app get <name>` or check the ArgoCD UI for error details
+- **Ingress not reachable** — verify Traefik is running (`kubectl get pods -n traefik`) and that your domain's DNS points to the cluster's external IP
+- **Secrets missing** — ensure the Infisical operator is synced, or create the required Kubernetes Secrets manually (check the chart's `README.md` for the expected Secret names)
+
 ## References
 
+- [Helm docs](https://helm.sh/docs/) — Kubernetes package manager documentation
+- [kubectl cheat sheet](https://kubernetes.io/docs/reference/kubectl/quick-reference/) — quick reference for common commands
+- [k3s](https://k3s.io/) — lightweight Kubernetes distribution
 - [Talos Linux](https://www.talos.dev/) — Kubernetes-focused Linux
 - [ArgoCD](https://argo-cd.readthedocs.io/) — GitOps continuous delivery
 - [Infisical](https://infisical.com/) — Secret management
@@ -191,5 +240,7 @@ npm run generate
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+If you find this useful:
 
 [![Buy Me A Coffee](https://www.buymeacoffee.com/assets/img/guidelines/download-assets-sm-2.svg)](https://www.buymeacoffee.com/hobroker)

--- a/packages/docs/src/generateMarkdownTable.ts
+++ b/packages/docs/src/generateMarkdownTable.ts
@@ -1,7 +1,9 @@
 import { markdownTable } from "markdown-table";
 import { ChartData } from "./types";
 
-const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
+const acronyms = new Set(["ai"]);
+const capitalize = (value: string) =>
+  acronyms.has(value) ? value.toUpperCase() : value.charAt(0).toUpperCase() + value.slice(1);
 
 export const generateMarkdownTable = (data: ChartData[]) => {
   const content = data.map(({ category, services }) => {


### PR DESCRIPTION
## Summary
- Added a plain-language intro explaining the repo's purpose before technical details
- Improved Getting Started with a k3s recommendation, ArgoCD explanation, and a concrete deploy example (both ArgoCD and Helm)
- Added **How It Works** section describing the data flow (Git → ArgoCD → Helm → Traefik → Service)
- Rewrote **Deploying a Chart** to lead with "customize first" and mention both deployment methods
- Clarified **Host Directories** as environment-specific with guidance on customizing paths
- Expanded **Secrets** with a manual fallback for non-Infisical users
- Added **Troubleshooting** section (Pending pods, sync failures, ingress, missing secrets)
- Expanded **References** with Helm docs, kubectl cheat sheet, k3s
- Fixed "Ai" → "AI" capitalization in the docs generate script

## Test plan
- [x] `npm run generate` runs successfully and produces correct output
- [ ] Review rendered markdown on GitHub for formatting/anchor issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)