### PR TITLE
fix(plex): mount nebula at /mnt/nebula instead of /nebula

### DIFF
--- a/charts/media/plex/README.md
+++ b/charts/media/plex/README.md
@@ -31,7 +31,7 @@ helm upgrade --install plex bjw-s/app-template \
 | source                           | containerPath | description                            |
 | -------------------------------- | ------------- | -------------------------------------- |
 | `/var/local/plex` (hostPath)     | `/config`     | Application configuration and database |
-| `192.168.50.7:/mnt/nebula` (NFS) | `/nebula`     | Access to media library                |
+| `192.168.50.7:/mnt/nebula` (NFS) | `/mnt/nebula` | Access to media library                |
 
 PV: `plex-config-pv` → PVC: `plex-config-pvc`
 PV: `plex-nebula-pv` → PVC: `plex-nebula-pvc`

--- a/charts/media/plex/values.yaml
+++ b/charts/media/plex/values.yaml
@@ -31,7 +31,7 @@ persistence:
   nebula:
     existingClaim: plex-nebula-pvc
     globalMounts:
-      - path: /nebula
+      - path: /mnt/nebula
 
 ingress:
   main:


### PR DESCRIPTION
## Summary

- Change plex nebula mount path from `/nebula` to `/mnt/nebula`

Aligns with the consistent `/mnt/nebula` mount path used across radarr, sonarr, jellyfin, and qbittorrent.

## Manual steps required after deploying

Update any Plex library paths that referenced `/nebula/...` to `/mnt/nebula/...` in **Settings → Libraries**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Plex chart storage configuration documentation with NFS source clarification.

* **Chores**
  * Updated Plex chart storage mount path from /nebula to /mnt/nebula for improved filesystem organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->