### PR TITLE
fix(media): set seerr targetRevision to HEAD

### DIFF
--- a/charts/media/seerr/application.yaml
+++ b/charts/media/seerr/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   sources:
     - repoURL: https://github.com/hobroker/selfhosted.git
-      targetRevision: feat/media-seerr
+      targetRevision: HEAD
       path: charts/media/seerr/config
     - repoURL: https://bjw-s-labs.github.io/helm-charts
       chart: app-template
@@ -20,7 +20,7 @@ spec:
         valueFiles:
           - $values/charts/media/seerr/values.yaml
     - repoURL: https://github.com/hobroker/selfhosted.git
-      targetRevision: feat/media-seerr
+      targetRevision: HEAD
       ref: values
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
## Summary

- Fixes `targetRevision` in seerr ArgoCD application from the feature branch name to `HEAD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to track the main release branch instead of a feature branch. This ensures the application deployment follows the stable main branch for improved consistency and stability across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->