### PR TITLE
chore(monitoring): bump kube-prometheus-stack to 82.10.4

### DIFF
--- a/apps/monitoring/prometheus-operator/application.yaml
+++ b/apps/monitoring/prometheus-operator/application.yaml
@@ -15,7 +15,7 @@ spec:
       path: apps/monitoring/prometheus-operator/config
     - repoURL: https://prometheus-community.github.io/helm-charts
       chart: kube-prometheus-stack
-      targetRevision: 82.4.3
+      targetRevision: 82.10.4
       helm:
         releaseName: prometheus-operator
         valueFiles:


### PR DESCRIPTION
## Summary
- Bumps kube-prometheus-stack from 82.4.3 to 82.10.4

Generated with [Claude Code](https://claude.com/claude-code)