### PR TITLE
fix: don't pass filenames to npm run generate in lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   },
   "lint-staged": {
     "*.{md,yaml}": "prettier --write",
-    "apps/**/README.md": "npm run generate"
+    "apps/**/README.md": "npm run generate --"
   }
 }


### PR DESCRIPTION
### Summary

`npm run generate` doesn't accept positional arguments but lint-staged was passing staged file paths to it. Fixed by adding `--` to prevent lint-staged from appending filenames.

### Type

- [ ] New app
- [ ] App update (version bump / config change)
- [x] Bug fix
- [ ] Other