### PR TITLE
fix: prevent lint-staged from passing file args to generate command

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   },
   "lint-staged": {
     "*.{md,yaml}": "prettier --write",
-    "apps/**/README.md": "npm run generate --"
+    "apps/**/README.md": "bash -c 'npm run generate'"
   }
 }


### PR DESCRIPTION
## Summary
- lint-staged appends staged file paths as positional arguments to configured commands
- `npm run generate` was receiving the README path as an argument, which the CLI rejects with "too many arguments"
- Wrapping in `bash -c '...'` causes lint-staged to pass the file path to bash (which ignores it), not to the generate command

## Test plan
- [ ] Stage an `apps/**/README.md` file and run `npx lint-staged` — `npm run generate` should run successfully without the "too many arguments" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)