### PR TITLE
chore(openclaw): upgrade chart to 1.5.12

### DIFF
--- a/apps/automation/openclaw/application.yaml
+++ b/apps/automation/openclaw/application.yaml
@@ -15,7 +15,7 @@ spec:
       path: apps/automation/openclaw/config
     - repoURL: https://serhanekicii.github.io/openclaw-helm
       chart: openclaw
-      targetRevision: 1.5.5
+      targetRevision: 1.5.12
       helm:
         valueFiles:
           - $values/apps/automation/openclaw/values.yaml


### PR DESCRIPTION
### Summary

Bumps the openclaw Helm chart from `1.5.5` to `1.5.12`.

### Type

- [ ] New app
- [x] App update (version bump / config change)
- [ ] Bug fix
- [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration with the latest version of a component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->