### PR TITLE
refactor(openclaw): switch to xrow OCI helm chart 1.17.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,10 @@ npm run generate
 
 ### Automation
 
-| App                                  | Description                                                                       | Source Code                            |
-| ------------------------------------ | --------------------------------------------------------------------------------- | -------------------------------------- |
-| [n8n](apps/automation/n8n)           | Workflow automation platform                                                      | <https://github.com/n8n-io/n8n>        |
-| [openclaw](apps/automation/openclaw) | AI assistant that connects to messaging platforms and executes tasks autonomously | <https://github.com/openclaw/openclaw> |
+| App                                  | Description                                                                       | Source Code                                    |
+| ------------------------------------ | --------------------------------------------------------------------------------- | ---------------------------------------------- |
+| [n8n](apps/automation/n8n)           | Workflow automation platform                                                      | <https://github.com/n8n-io/n8n>                |
+| [openclaw](apps/automation/openclaw) | AI assistant that connects to messaging platforms and executes tasks autonomously | <https://gitlab.com/xrow-public/helm-openclaw> |
 
 ### Backup
 

--- a/apps/automation/openclaw/README.md
+++ b/apps/automation/openclaw/README.md
@@ -2,8 +2,8 @@
 
 > AI assistant that connects to messaging platforms and executes tasks autonomously
 
-Source Code: https://github.com/openclaw/openclaw
-Chart: https://github.com/serhanekicii/openclaw-helm
+Source Code: https://gitlab.com/xrow-public/helm-openclaw
+Chart: oci://registry.gitlab.com/xrow-public/helm-openclaw/charts/openclaw
 
 ## Installing/upgrading
 
@@ -19,23 +19,25 @@ argocd app sync openclaw
 
 ```sh
 kubectl apply -f config
-helm repo add openclaw https://serhanekicii.github.io/openclaw-helm
-helm repo update openclaw
-helm upgrade --install openclaw openclaw/openclaw -f values.yaml
+helm upgrade --install openclaw \
+  oci://registry.gitlab.com/xrow-public/helm-openclaw/charts/openclaw \
+  --version 1.17.2 \
+  -f values.yaml
 ```
 
 ## Pairing a device
 
 ```sh
-kubectl port-forward -n default svc/openclaw 18789:18789
-# Open http://localhost:18789, enter the gateway token, click Connect
+# Read the auto-generated gateway token
+kubectl get secret -n default openclaw-token -o jsonpath='{.data.token}' | base64 -d; echo
 
-kubectl exec -n default deployment/openclaw -c main -- node dist/index.js devices list
-kubectl exec -n default deployment/openclaw -c main -- node dist/index.js devices approve <REQUEST_ID>
+# Forward the UI
+kubectl port-forward -n default svc/openclaw 18789:18789
+# Open http://localhost:18789, paste the token, click Connect
 ```
 
 ## Storage
 
-| source                | container path         | type       | description                            |
-| --------------------- | ---------------------- | ---------- | -------------------------------------- |
-| `/var/local/openclaw` | `/home/node/.openclaw` | `hostPath` | Config, sessions, and installed skills |
+| source                | container path                | type       | description                            |
+| --------------------- | ----------------------------- | ---------- | -------------------------------------- |
+| `/var/local/openclaw` | `/opt/app-root/src/.openclaw` | `hostPath` | Config, sessions, and installed skills |

--- a/apps/automation/openclaw/application.yaml
+++ b/apps/automation/openclaw/application.yaml
@@ -13,9 +13,9 @@ spec:
     - repoURL: https://github.com/hobroker/selfhosted.git
       targetRevision: HEAD
       path: apps/automation/openclaw/config
-    - repoURL: https://serhanekicii.github.io/openclaw-helm
+    - repoURL: registry.gitlab.com/xrow-public/helm-openclaw/charts
       chart: openclaw
-      targetRevision: 1.5.12
+      targetRevision: 1.17.2
       helm:
         valueFiles:
           - $values/apps/automation/openclaw/values.yaml
@@ -26,12 +26,6 @@ spec:
     server: https://kubernetes.default.svc
     namespace: default
   revisionHistoryLimit: 3
-  ignoreDifferences:
-    - group: ""
-      kind: ConfigMap
-      name: openclaw
-      jsonPointers:
-        - /data
   syncPolicy:
     syncOptions:
       - CreateNamespace=true

--- a/apps/automation/openclaw/values.yaml
+++ b/apps/automation/openclaw/values.yaml
@@ -1,17 +1,20 @@
-controllers:
-  main:
-    pod:
-      annotations:
-        secret.reloader.stakater.com/reload: "infisical-openclaw-secret"
-    containers:
-      main:
-        envFrom:
-          - secretRef:
-              name: infisical-openclaw-secret
-      chromium:
-        enabled: false
+image:
+  tag: 1.17.2
+
+service:
+  type: ClusterIP
+  port: 18789
+
 persistence:
-  data:
-    storageClassName: ""
-    globalMounts:
-      - path: /home/node/.openclaw
+  storageClass: ""
+  size: 5Gi
+
+config:
+  timezone: Europe/Bucharest
+  secrets: []
+
+browserless:
+  enabled: false
+
+ingress:
+  enabled: false


### PR DESCRIPTION
### Summary

Replaces the `serhanekicii/openclaw-helm` chart (bjw-s-labs/app-template based, 1.5.12) with the xrow `helm-openclaw` chart published to ArtifactHub, hosted as **OCI** at `oci://registry.gitlab.com/xrow-public/helm-openclaw/charts/openclaw` (1.17.2).

The two charts share nothing in common schema-wise, so this is a chart replacement: `values.yaml` is rewritten for the new chart's structure (`image`, `service`, `persistence`, `config`, `browserless`, `ingress`); the README install/pairing flow is updated; and the stale ConfigMap `ignoreDifferences` block in `application.yaml` is dropped.

### Type

- [x] App update (version bump / config change)

### What's different in the new chart

| Aspect | Before | After |
| --- | --- | --- |
| Repo type | HTTPS Helm | **OCI** |
| Repo URL | `https://serhanekicii.github.io/openclaw-helm` | `registry.gitlab.com/xrow-public/helm-openclaw/charts` |
| Version | 1.5.12 | 1.17.2 |
| Persistence mount | `/home/node/.openclaw` | `/opt/app-root/src/.openclaw` |
| Container uid:gid | (image default) | `1001:1001` |
| Gateway token | manual pairing via CLI | chart-managed `openclaw-token` Secret |
| Browserless | optional sidecar (disabled) | bundled subchart (disabled here) |

### Reviewer notes / pre-deploy checklist

- **OCI helm registration in ArgoCD** — no app in this repo currently uses an OCI chart. The cluster's ArgoCD needs the repo registered with `enableOCI: true` (e.g. `argocd repo add registry.gitlab.com/xrow-public/helm-openclaw/charts --type helm --enable-oci`) before sync will succeed.
- **Hostpath migration** — the new container runs as `1001:1001` and mounts at `/opt/app-root/src/.openclaw`. Existing data at `/var/local/openclaw/` is at the wrong path and ownership; before first sync, `sudo rm -rf /var/local/openclaw/* && sudo chown -R 1001:1001 /var/local/openclaw` on the host.
- **Infisical secret integration is dropped.** The new chart's deployment hardcodes `envFrom: secretRef: <fullname>` to its own auto-generated Secret with no `extraEnvFrom` hook. `config.secrets: []` is left empty for now; the chart still auto-generates `openclaw-token`. If extra envs are needed later, either inline them into `config.secrets[]` (chart renders to a Secret) or fork the chart.
- Namespace stays `default` to match the rest of the repo (the chart's README suggests `openclaw`, but consistency wins here).

### Verification

- `npm run generate -- --check`, `npm run lint`, `npm run typecheck`, `npm run test` — all green locally.
- After merge + ArgoCD sync:
  - `kubectl rollout status deploy/openclaw -n default`
  - `kubectl get pvc -n default openclaw` should bind to `openclaw-pv`
  - `kubectl get secret -n default openclaw-token` exists
  - Port-forward 18789 → token from above unlocks the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Helm installation instructions and chart source to GitLab OCI registry
  * Upgraded chart version to 1.17.2
  * Updated device pairing procedure with Kubernetes secret token retrieval
  * Updated storage path configuration

* **Chores**
  * Updated default service and application settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->