### PR TITLE
fix(openclaw): mount emptyDir at /home/node/.npm

### DIFF
--- a/apps/automation/openclaw/values.yaml
+++ b/apps/automation/openclaw/values.yaml
@@ -7,6 +7,13 @@ app-template:
   persistence:
     data:
       storageClass: ""
+    npm-cache:
+      enabled: true
+      type: emptyDir
+      advancedMounts:
+        main:
+          main:
+            - path: /home/node/.npm
   configMaps:
     config:
       data:


### PR DESCRIPTION
### Summary

Adds an emptyDir volume mounted at `/home/node/.npm` on the openclaw main container so npm has a writable cache directory inside the container's home. The upstream chart only mounts `/home/node/.openclaw` from the data PVC, leaving `~/.npm` missing.

### Type

- [ ] New app
- [x] App update (version bump / config change)
- [ ] Bug fix
- [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced npm caching configuration for improved build efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hobroker/selfhosted/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->