### PR TITLE
refactor(openclaw): migrate to bjw-s-labs app-template chart

### DIFF
--- a/apps/automation/openclaw/application.yaml
+++ b/apps/automation/openclaw/application.yaml
@@ -13,10 +13,11 @@ spec:
     - repoURL: https://github.com/hobroker/selfhosted.git
       targetRevision: HEAD
       path: apps/automation/openclaw/config
-    - repoURL: https://serhanekicii.github.io/openclaw-helm
-      chart: openclaw
-      targetRevision: 1.5.36
+    - repoURL: https://bjw-s-labs.github.io/helm-charts
+      chart: app-template
+      targetRevision: 4.6.2
       helm:
+        releaseName: openclaw
         valueFiles:
           - $values/apps/automation/openclaw/values.yaml
     - repoURL: https://github.com/hobroker/selfhosted.git

--- a/apps/automation/openclaw/values.yaml
+++ b/apps/automation/openclaw/values.yaml
@@ -1,83 +1,479 @@
-app-template:
-  controllers:
-    main:
-      containers:
-        chromium:
-          enabled: false
-  persistence:
+# OpenClaw values for bjw-s-labs/app-template (vendored from openclaw chart 1.5.36).
+# Upstream chart (serhanekicii/openclaw-helm) was archived 2026-05-25.
+
+openclawVersion: "2026.5.12"
+chromiumVersion: "148.0.7778.97"
+configMode: merge
+skills:
+  - weather
+  - gog
+
+defaultPodOptions:
+  securityContext:
+    fsGroup: 1000
+    fsGroupChangePolicy: OnRootMismatch
+
+controllers:
+  main:
+    replicas: 1
+    strategy: Recreate
+
+    initContainers:
+      init-config:
+        image:
+          repository: ghcr.io/openclaw/openclaw
+          tag: 2026.5.12
+        command:
+          - sh
+          - /scripts/init-config.sh
+        env:
+          CONFIG_MODE: '{{ .Values.configMode | default "merge" }}'
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+
+      init-skills:
+        image:
+          repository: ghcr.io/openclaw/openclaw
+          tag: 2026.5.12
+        command:
+          - sh
+          - /scripts/init-skills.sh
+        env:
+          SKILLS_TO_INSTALL: '{{ .Values.skills | join " " }}'
+          HOME: /tmp
+          NPM_CONFIG_CACHE: /tmp/.npm
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+
+    containers:
+      main:
+        image:
+          repository: ghcr.io/openclaw/openclaw
+          tag: 2026.5.12
+          pullPolicy: IfNotPresent
+        command:
+          - node
+          - dist/index.js
+        args:
+          - gateway
+          - --bind
+          - lan
+          - --port
+          - "18789"
+        envFrom: []
+        env: {}
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+        resources:
+          requests:
+            cpu: 200m
+            memory: 512Mi
+          limits:
+            cpu: 2000m
+            memory: 2Gi
+        probes:
+          liveness:
+            enabled: true
+            type: TCP
+            spec:
+              tcpSocket:
+                port: 18789
+              initialDelaySeconds: 30
+              periodSeconds: 30
+              timeoutSeconds: 5
+              failureThreshold: 3
+          readiness:
+            enabled: true
+            type: TCP
+            spec:
+              tcpSocket:
+                port: 18789
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 3
+          startup:
+            enabled: true
+            type: TCP
+            spec:
+              tcpSocket:
+                port: 18789
+              initialDelaySeconds: 5
+              periodSeconds: 5
+              timeoutSeconds: 5
+              failureThreshold: 30
+
+      chromium:
+        enabled: false
+        image:
+          repository: chromedp/headless-shell
+          tag: "{{ .Values.chromiumVersion }}"
+        env:
+          # Fontconfig cache needs a writable directory
+          XDG_CACHE_HOME: /tmp
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /json/version
+                port: 9222
+              initialDelaySeconds: 10
+              periodSeconds: 30
+              timeoutSeconds: 5
+              failureThreshold: 6
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /json/version
+                port: 9222
+              initialDelaySeconds: 5
+              periodSeconds: 10
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /json/version
+                port: 9222
+              initialDelaySeconds: 5
+              periodSeconds: 5
+              timeoutSeconds: 5
+              failureThreshold: 12
+
+configMaps:
+  scripts:
+    enabled: true
     data:
-      storageClass: ""
-    npm-cache:
-      enabled: true
-      type: emptyDir
-      advancedMounts:
-        main:
-          main:
-            - path: /home/node/.npm
-  configMaps:
-    config:
-      data:
-        openclaw.json: |
-          {
-            "gateway": {
-              "port": 18789,
-              "mode": "local",
-              "trustedProxies": ["10.0.0.1"]
-            },
-            "browser": {
-              "enabled": true,
-              "defaultProfile": "default",
-              "profiles": {
-                "default": {
-                  "cdpUrl": "http://localhost:9222",
-                  "color": "#4285F4"
+      init-config.sh: |
+        log() { echo "[$(date -Iseconds)] [init-config] $*"; }
+
+        log "Starting config initialization"
+        mkdir -p /home/node/.openclaw
+        CONFIG_MODE="${CONFIG_MODE:-merge}"
+
+        if [ "$CONFIG_MODE" = "merge" ] && [ -f /home/node/.openclaw/openclaw.json ]; then
+          log "Mode: merge - merging Helm config with existing config"
+          if node -e "
+            const fs = require('fs');
+            // Strip JSON5 single-line comments while preserving // inside strings (e.g. URLs)
+            const stripComments = (s) => {
+              let r = '', q = false, i = 0;
+              while (i < s.length) {
+                if (q) {
+                  if (s[i] === '\\\\') { r += s[i] + s[i+1]; i += 2; continue; }
+                  if (s[i] === '\"') q = false;
+                  r += s[i++];
+                } else if (s[i] === '\"') {
+                  q = true; r += s[i++];
+                } else if (s[i] === '/' && s[i+1] === '/') {
+                  while (i < s.length && s[i] !== '\n') i++;
+                } else { r += s[i++]; }
+              }
+              return r;
+            };
+            let existing;
+            try {
+              existing = JSON.parse(stripComments(fs.readFileSync('/home/node/.openclaw/openclaw.json', 'utf8')));
+            } catch (e) {
+              console.error('[init-config] Warning: existing config is not valid JSON, will overwrite');
+              process.exit(1);
+            }
+            const helm = JSON.parse(stripComments(fs.readFileSync('/config/openclaw.json', 'utf8')));
+            const deepMerge = (target, source) => {
+              for (const key of Object.keys(source)) {
+                if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+                  target[key] = target[key] || {};
+                  deepMerge(target[key], source[key]);
+                } else {
+                  target[key] = source[key];
                 }
               }
-            },
-            "agents": {
-              "defaults": {
-                "workspace": "/home/node/.openclaw/workspace",
-                "model": {
-                  "primary": "deepseek/deepseek-v4-pro"
-                },
-                "userTimezone": "UTC",
-                "timeoutSeconds": 600,
-                "maxConcurrent": 1
+              return target;
+            };
+            const merged = deepMerge(existing, helm);
+            fs.writeFileSync('/home/node/.openclaw/openclaw.json', JSON.stringify(merged, null, 2));
+          "; then
+            log "Config merged successfully"
+          else
+            log "WARNING: Merge failed (existing config may not be valid JSON), falling back to overwrite"
+            cp /config/openclaw.json /home/node/.openclaw/openclaw.json
+          fi
+        else
+          if [ ! -f /home/node/.openclaw/openclaw.json ]; then
+            log "Fresh install - writing initial config"
+          else
+            log "Mode: overwrite - replacing config with Helm values"
+          fi
+          cp /config/openclaw.json /home/node/.openclaw/openclaw.json
+        fi
+        log "Config initialization complete"
+
+      init-skills.sh: |
+        log() { echo "[$(date -Iseconds)] [init-skills] $*"; }
+
+        log "Starting skills initialization"
+
+        # ============================================================
+        # Runtime Dependencies
+        # ============================================================
+        # Some skills require additional runtimes (Python, Go, etc.)
+        # Install them here so they persist across pod restarts.
+        #
+        # Example: Install uv (Python package manager) for Python skills
+        # mkdir -p /home/node/.openclaw/bin
+        # if [ ! -f /home/node/.openclaw/bin/uv ]; then
+        #   log "Installing uv..."
+        #   curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/home/node/.openclaw/bin sh
+        # fi
+        #
+        # Example: Install pnpm and packages for interfaces (e.g., MS Teams)
+        # The read-only filesystem and non-root UID prevent writing to default
+        # pnpm paths (/usr/local/lib/node_modules, ~/.local/share/pnpm, etc.).
+        # Redirect PNPM_HOME to the PVC so the binary persists across restarts.
+        # The init container's HOME=/tmp ensures pnpm's cache, state, and config
+        # writes land on /tmp (writable emptyDir). The store goes on the PVC so
+        # hardlinks work (same filesystem as node_modules) and persist.
+        # PNPM_HOME=/home/node/.openclaw/pnpm
+        # mkdir -p "$PNPM_HOME"
+        # if [ ! -f "$PNPM_HOME/pnpm" ]; then
+        #   log "Installing pnpm..."
+        #   curl -fsSL https://get.pnpm.io/install.sh | env PNPM_HOME="$PNPM_HOME" SHELL=/bin/sh sh -
+        # fi
+        # export PATH="$PNPM_HOME:$PATH"
+        # log "Installing interface dependencies..."
+        # cd /home/node/.openclaw
+        # pnpm install <your-package> --store-dir /home/node/.openclaw/.pnpm-store
+
+        # ============================================================
+        # Skill Installation
+        # ============================================================
+        # Installs skills listed in SKILLS_TO_INSTALL (set via the top-level skills: [] value).
+        # Set skills: [] in your values to skip skill installation entirely.
+        mkdir -p /home/node/.openclaw/workspace/skills
+        cd /home/node/.openclaw/workspace
+        install_skill() {
+          skill="$1"
+          SKILL_NAME="$(basename "$skill")"
+          if [ -z "$skill" ]; then
+            return 0
+          fi
+          if [ -d "skills/$SKILL_NAME" ]; then
+            log "Skill already installed: $skill"
+            return 0
+          fi
+          log "Installing skill: $skill"
+          attempts=6
+          delay=5
+          for i in $(seq 1 "$attempts"); do
+            if npx -y clawhub install "$skill" --no-input; then
+              log "Installed skill: $skill"
+              return 0
+            fi
+            # Add a little jitter so concurrent pods don't retry in lockstep.
+            jitter=$((RANDOM % 5))
+            if [ "$i" -lt "$attempts" ]; then
+              log "WARNING: Failed to install skill: $skill (attempt $i/$attempts). Retrying in $((delay + jitter))s..."
+              sleep $((delay + jitter))
+              delay=$((delay * 2))
+            fi
+          done
+          log "WARNING: Failed to install skill after $attempts attempts: $skill"
+          return 1
+        }
+        for skill in $SKILLS_TO_INSTALL; do
+          install_skill "$skill" || true
+        done
+        log "Skills initialization complete"
+
+  config:
+    enabled: true
+    data:
+      bash_aliases: |
+        alias openclaw='node /app/dist/index.js'
+      openclaw.json: |
+        {
+          "gateway": {
+            "port": 18789,
+            "mode": "local",
+            "trustedProxies": ["10.0.0.1"]
+          },
+          "browser": {
+            "enabled": true,
+            "defaultProfile": "default",
+            "profiles": {
+              "default": {
+                "cdpUrl": "http://localhost:9222",
+                "color": "#4285F4"
+              }
+            }
+          },
+          "agents": {
+            "defaults": {
+              "workspace": "/home/node/.openclaw/workspace",
+              "model": {
+                "primary": "deepseek/deepseek-v4-pro"
               },
-              "list": [
-                {
-                  "id": "main",
-                  "default": true,
-                  "identity": {
-                    "name": "OpenClaw",
-                    "emoji": "🦞"
-                  }
-                }
-              ]
+              "userTimezone": "UTC",
+              "timeoutSeconds": 600,
+              "maxConcurrent": 1
             },
-            "session": {
-              "scope": "per-sender",
-              "store": "/home/node/.openclaw/sessions",
-              "reset": {
-                "mode": "idle",
-                "idleMinutes": 60
+            "list": [
+              {
+                "id": "main",
+                "default": true,
+                "identity": {
+                  "name": "OpenClaw",
+                  "emoji": "🦞"
+                }
               }
-            },
-            "logging": {
-              "level": "info",
-              "consoleLevel": "info",
-              "consoleStyle": "compact",
-              "redactSensitive": "tools"
-            },
-            "tools": {
-              "profile": "full",
-              "web": {
-                "search": {
-                  "enabled": false
-                },
-                "fetch": {
-                  "enabled": true
-                }
+            ]
+          },
+          "session": {
+            "scope": "per-sender",
+            "store": "/home/node/.openclaw/sessions",
+            "reset": {
+              "mode": "idle",
+              "idleMinutes": 60
+            }
+          },
+          "logging": {
+            "level": "info",
+            "consoleLevel": "info",
+            "consoleStyle": "compact",
+            "redactSensitive": "tools"
+          },
+          "tools": {
+            "profile": "full",
+            "web": {
+              "search": {
+                "enabled": false
+              },
+              "fetch": {
+                "enabled": true
               }
             }
           }
+        }
+
+service:
+  main:
+    controller: main
+    ipFamilyPolicy: SingleStack
+    ipFamilies:
+      - IPv4
+    ports:
+      http:
+        port: 18789
+
+persistence:
+  scripts:
+    enabled: true
+    type: configMap
+    identifier: scripts
+    advancedMounts:
+      main:
+        init-config:
+          - path: /scripts
+            readOnly: true
+        init-skills:
+          - path: /scripts
+            readOnly: true
+
+  config:
+    enabled: true
+    type: configMap
+    identifier: config
+    advancedMounts:
+      main:
+        init-config:
+          - path: /config
+            readOnly: true
+
+  bash-aliases:
+    enabled: true
+    type: configMap
+    identifier: config
+    advancedMounts:
+      main:
+        main:
+          - path: /home/node/.bash_aliases
+            subPath: bash_aliases
+            readOnly: true
+
+  data:
+    enabled: true
+    type: persistentVolumeClaim
+    accessMode: ReadWriteOnce
+    size: 5Gi
+    storageClass: ""
+    advancedMounts:
+      main:
+        init-config:
+          - path: /home/node/.openclaw
+        init-skills:
+          - path: /home/node/.openclaw
+        main:
+          - path: /home/node/.openclaw
+
+  tmp:
+    enabled: true
+    type: emptyDir
+    advancedMounts:
+      main:
+        init-config:
+          - path: /tmp
+        init-skills:
+          - path: /tmp
+        main:
+          - path: /tmp
+        chromium:
+          - path: /tmp
+
+  npm-cache:
+    enabled: true
+    type: emptyDir
+    advancedMounts:
+      main:
+        main:
+          - path: /home/node/.npm

--- a/apps/automation/openclaw/values.yaml
+++ b/apps/automation/openclaw/values.yaml
@@ -1,8 +1,6 @@
 # OpenClaw values for bjw-s-labs/app-template (vendored from openclaw chart 1.5.36).
 # Upstream chart (serhanekicii/openclaw-helm) was archived 2026-05-25.
 
-openclawVersion: "2026.5.12"
-chromiumVersion: "148.0.7778.97"
 configMode: merge
 skills:
   - weather
@@ -28,7 +26,7 @@ controllers:
           - /scripts/init-config.sh
         env:
           CONFIG_MODE: '{{ .Values.configMode | default "merge" }}'
-        securityContext:
+        securityContext: &containerSecurityContext
           runAsUser: 1000
           runAsGroup: 1000
           runAsNonRoot: true
@@ -49,15 +47,7 @@ controllers:
           SKILLS_TO_INSTALL: '{{ .Values.skills | join " " }}'
           HOME: /tmp
           NPM_CONFIG_CACHE: /tmp/.npm
-        securityContext:
-          runAsUser: 1000
-          runAsGroup: 1000
-          runAsNonRoot: true
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
+        securityContext: *containerSecurityContext
 
     containers:
       main:
@@ -76,15 +66,7 @@ controllers:
           - "18789"
         envFrom: []
         env: {}
-        securityContext:
-          runAsUser: 1000
-          runAsGroup: 1000
-          runAsNonRoot: true
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
+        securityContext: *containerSecurityContext
         resources:
           requests:
             cpu: 200m
@@ -113,22 +95,12 @@ controllers:
               periodSeconds: 10
               timeoutSeconds: 5
               failureThreshold: 3
-          startup:
-            enabled: true
-            type: TCP
-            spec:
-              tcpSocket:
-                port: 18789
-              initialDelaySeconds: 5
-              periodSeconds: 5
-              timeoutSeconds: 5
-              failureThreshold: 30
 
       chromium:
         enabled: false
         image:
           repository: chromedp/headless-shell
-          tag: "{{ .Values.chromiumVersion }}"
+          tag: 148.0.7778.97
         env:
           # Fontconfig cache needs a writable directory
           XDG_CACHE_HOME: /tmp
@@ -254,42 +226,9 @@ configMaps:
 
         log "Starting skills initialization"
 
-        # ============================================================
-        # Runtime Dependencies
-        # ============================================================
-        # Some skills require additional runtimes (Python, Go, etc.)
-        # Install them here so they persist across pod restarts.
-        #
-        # Example: Install uv (Python package manager) for Python skills
-        # mkdir -p /home/node/.openclaw/bin
-        # if [ ! -f /home/node/.openclaw/bin/uv ]; then
-        #   log "Installing uv..."
-        #   curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/home/node/.openclaw/bin sh
-        # fi
-        #
-        # Example: Install pnpm and packages for interfaces (e.g., MS Teams)
-        # The read-only filesystem and non-root UID prevent writing to default
-        # pnpm paths (/usr/local/lib/node_modules, ~/.local/share/pnpm, etc.).
-        # Redirect PNPM_HOME to the PVC so the binary persists across restarts.
-        # The init container's HOME=/tmp ensures pnpm's cache, state, and config
-        # writes land on /tmp (writable emptyDir). The store goes on the PVC so
-        # hardlinks work (same filesystem as node_modules) and persist.
-        # PNPM_HOME=/home/node/.openclaw/pnpm
-        # mkdir -p "$PNPM_HOME"
-        # if [ ! -f "$PNPM_HOME/pnpm" ]; then
-        #   log "Installing pnpm..."
-        #   curl -fsSL https://get.pnpm.io/install.sh | env PNPM_HOME="$PNPM_HOME" SHELL=/bin/sh sh -
-        # fi
-        # export PATH="$PNPM_HOME:$PATH"
-        # log "Installing interface dependencies..."
-        # cd /home/node/.openclaw
-        # pnpm install <your-package> --store-dir /home/node/.openclaw/.pnpm-store
-
-        # ============================================================
-        # Skill Installation
-        # ============================================================
         # Installs skills listed in SKILLS_TO_INSTALL (set via the top-level skills: [] value).
         # Set skills: [] in your values to skip skill installation entirely.
+        # If a skill needs an extra runtime (uv, pnpm, etc.), install it here before the loop.
         mkdir -p /home/node/.openclaw/workspace/skills
         cd /home/node/.openclaw/workspace
         install_skill() {
@@ -329,8 +268,6 @@ configMaps:
   config:
     enabled: true
     data:
-      bash_aliases: |
-        alias openclaw='node /app/dist/index.js'
       openclaw.json: |
         {
           "gateway": {
@@ -428,17 +365,6 @@ persistence:
       main:
         init-config:
           - path: /config
-            readOnly: true
-
-  bash-aliases:
-    enabled: true
-    type: configMap
-    identifier: config
-    advancedMounts:
-      main:
-        main:
-          - path: /home/node/.bash_aliases
-            subPath: bash_aliases
             readOnly: true
 
   data:

--- a/apps/automation/openclaw/values.yaml
+++ b/apps/automation/openclaw/values.yaml
@@ -250,7 +250,8 @@ configMaps:
               return 0
             fi
             # Add a little jitter so concurrent pods don't retry in lockstep.
-            jitter=$((RANDOM % 5))
+            # POSIX sh has no $RANDOM, so read one byte from /dev/urandom (fall back to 0).
+            jitter=$(( $(od -An -N1 -tu1 /dev/urandom 2>/dev/null || echo 0) % 5 ))
             if [ "$i" -lt "$attempts" ]; then
               log "WARNING: Failed to install skill: $skill (attempt $i/$attempts). Retrying in $((delay + jitter))s..."
               sleep $((delay + jitter))

--- a/apps/automation/openclaw/values.yaml
+++ b/apps/automation/openclaw/values.yaml
@@ -104,15 +104,7 @@ controllers:
         env:
           # Fontconfig cache needs a writable directory
           XDG_CACHE_HOME: /tmp
-        securityContext:
-          runAsUser: 1000
-          runAsGroup: 1000
-          runAsNonRoot: true
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
+        securityContext: *containerSecurityContext
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
### Summary

Migrates the openclaw deployment off the archived `serhanekicii/openclaw-helm` chart (archived 2026-05-25) onto the maintained `bjw-s-labs/app-template` chart (v4.6.2), and reimplements the behaviour the old chart provided internally:

- Init containers now seed/merge `openclaw.json` onto the PVC (merge mode preserves runtime-written config across restarts) and install the configured skills, all running non-root with a read-only root filesystem and dropped capabilities.
- Trims the migrated values: collapses the three identical container `securityContext` blocks into a single YAML anchor, drops the redundant TCP startup probe on the main container, and removes an unused `bash_aliases` configmap entry plus a stale runtime-dependency comment block.

Verified with `helm template openclaw bjw-s-labs/app-template --version 4.6.2 -f apps/automation/openclaw/values.yaml`: renders cleanly (ConfigMap/Deployment/PVC/Service, liveness + readiness probes, `readOnlyRootFilesystem` on all containers, no `bash_aliases`).

### Type

- [x] App update (version bump / config change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment to include container liveness/readiness checks, resource requests/limits, and a single-replica restart strategy.
  * Added init routines to bootstrap and merge existing configuration with provided defaults, and to install skills automatically with retry/backoff.
  * Introduced shared securityContext for containers.
  * Enabled persistent storage for app data and cache plus ephemeral tmp/npm mounts.
  * Expanded chart values to fully configure the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->