### PR TITLE
fix(openclaw): remove deepseek primary model override

### DIFF
--- a/apps/automation/openclaw/values.yaml
+++ b/apps/automation/openclaw/values.yaml
@@ -281,9 +281,6 @@ configMaps:
           "agents": {
             "defaults": {
               "workspace": "/home/node/.openclaw/workspace",
-              "model": {
-                "primary": "deepseek/deepseek-v4-pro"
-              },
               "userTimezone": "UTC",
               "timeoutSeconds": 600,
               "maxConcurrent": 1


### PR DESCRIPTION
### Summary

Removes the hardcoded `model.primary: deepseek/deepseek-v4-pro` override from the openclaw agent defaults. Agents now fall back to their own default model selection instead of being forced onto deepseek.

### Type

- [ ] New app
- [x] App update (version bump / config change)
- [ ] Bug fix
- [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a hardcoded default model setting from configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->