### PR TITLE
fix(longhorn): pin longhorn-frontend nodePort to stop ArgoCD drift

### DIFF
--- a/apps/system/longhorn/values.yaml
+++ b/apps/system/longhorn/values.yaml
@@ -4,6 +4,11 @@ preUpgradeChecker:
 service:
   ui:
     type: LoadBalancer
+    # Pin the auto-assigned NodePort so the rendered manifest matches the live
+    # Service. LoadBalancer Services also allocate a NodePort; when left unset
+    # the chart renders `nodePort: null` and ArgoCD reports a permanent diff
+    # against the value Kubernetes assigned (32709).
+    nodePort: 32709
     annotations:
       metallb.io/loadBalancerIPs: 192.168.50.204
 


### PR DESCRIPTION
## Problem

`argocd app diff longhorn` reports a permanent, un-syncable diff:

```
===== /Service longhorn-system/longhorn-frontend ======
82d81
<     nodePort: 32709
```

The `longhorn-frontend` UI Service is `type: LoadBalancer`, which also allocates a NodePort. With `service.ui.nodePort` unset, the chart renders `nodePort: null` in the desired manifest while Kubernetes assigns one at runtime (`32709`). ArgoCD therefore always sees the live Service carrying a field the desired state lacks, and the app never reaches a clean Synced state.

## Fix

Pin the already-assigned NodePort via the chart's native `service.ui.nodePort` value so the rendered manifest matches the live Service. Verified with `helm template` — the frontend Service now renders `nodePort: 32709`.

No change to the running Service (it already has 32709); this only makes git reflect reality so the drift clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configured the Longhorn UI to use a fixed network port for consistent access.
  * Added documentation clarifying service synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->