### PR TITLE
feat(floppy): add Floppy media tracker with in-pod Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ npm run generate
 | [bazarr](apps/media/bazarr)             | Companion application to Sonarr and Radarr that manages and downloads subtitles.          | <https://github.com/morpheus65535/bazarr>      |
 | [fileflows](apps/media/fileflows)       | File processing application                                                               | <https://github.com/revenz/FileFlows>          |
 | [flaresolverr](apps/media/flaresolverr) | Proxy server to bypass Cloudflare protection                                              | <https://github.com/FlareSolverr/FlareSolverr> |
+| [floppy](apps/media/floppy)             | Self-hosted all-in-one media tracker and Trakt alternative.                               | <https://github.com/dannyvfilms/Floppy>        |
 | [jellyfin](apps/media/jellyfin)         | An open-source media server                                                               | <https://github.com/jellyfin/jellyfin>         |
 | [plex](apps/media/plex)                 | A media server that organizes and streams video and audio content across devices.         | <https://www.plex.tv/>                         |
 | [prowlarr](apps/media/prowlarr)         | Indexer manager/proxy built on the popular \*arr stack to integrate with various PVR apps | <https://github.com/Prowlarr/Prowlarr>         |

--- a/apps/media/floppy/README.md
+++ b/apps/media/floppy/README.md
@@ -1,0 +1,58 @@
+# `floppy`
+
+> Self-hosted all-in-one media tracker and Trakt alternative.
+
+Source Code: https://github.com/dannyvfilms/Floppy
+Chart: https://bjw-s-labs.github.io/helm-charts/docs/app-template/
+
+## Installing/upgrading
+
+```sh
+# Register / update the Application resource
+kubectl apply -f application.yaml
+
+# Then sync the workload - via ArgoCD UI or:
+argocd app sync floppy
+```
+
+### Manual Helm (without ArgoCD)
+
+```sh
+kubectl apply -k config
+helm repo add bjw-s https://bjw-s-labs.github.io/helm-charts
+helm repo update bjw-s
+helm upgrade --install floppy bjw-s/app-template -f values.yaml
+```
+
+## Configuration
+
+Floppy is a Django app served on port `8000` and reached at
+`https://floppy.hobroker.me` through Traefik. It requires a Redis instance, which
+runs as a `redis` sidecar container in the same pod (`REDIS_URL=redis://localhost:6379`).
+The Redis data lives on an `emptyDir` and is treated as an ephemeral cache/session
+store — a pod restart just means re-logging in and re-running background metadata jobs.
+
+Metadata providers use `TMDB_API` (themoviedb.org) and `TVDB_API_KEY` (thetvdb.com).
+
+### Creating the first account
+
+`REGISTRATION` is set to `"true"` in `values.yaml` so you can create your account on
+first launch. **Set it to `"false"` and re-sync once your account exists** to close
+public signups, since the ingress is internet-facing.
+
+## Storage
+
+| source              | container path | type       | description                                 |
+| ------------------- | -------------- | ---------- | ------------------------------------------- |
+| `/var/local/floppy` | `/floppy/db`   | `hostPath` | SQLite database                             |
+| —                   | `/data`        | `emptyDir` | Redis cache/session store (redis container) |
+
+### Secrets
+
+The following environment variables are required and sourced from the `infisical-floppy-secret`:
+
+| name           | description                   |
+| -------------- | ----------------------------- |
+| `SECRET`       | Django secret key             |
+| `TMDB_API`     | TMDB (themoviedb.org) API key |
+| `TVDB_API_KEY` | TVDB (thetvdb.com) API key    |

--- a/apps/media/floppy/application.yaml
+++ b/apps/media/floppy/application.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: floppy
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  labels:
+    category: media
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/hobroker/selfhosted.git
+      targetRevision: HEAD
+      path: apps/media/floppy/config
+    - repoURL: https://bjw-s-labs.github.io/helm-charts
+      chart: app-template
+      targetRevision: 5.0.1
+      helm:
+        valueFiles:
+          - $values/apps/media/floppy/values.yaml
+    - repoURL: https://github.com/hobroker/selfhosted.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  revisionHistoryLimit: 3
+  syncPolicy: {}

--- a/apps/media/floppy/config/infisical-floppy-secret.yaml
+++ b/apps/media/floppy/config/infisical-floppy-secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: infisical-floppy-secret
+  namespace: default
+spec:
+  resyncInterval: 60
+  authentication:
+    universalAuth:
+      secretsScope:
+        projectSlug: kira
+        envSlug: prod
+        secretsPath: "/floppy"
+        recursive: true
+      credentialsRef:
+        secretName: universal-auth-credentials
+        secretNamespace: infisical-operator-system
+  managedKubeSecretReferences:
+    - secretName: infisical-floppy-secret
+      secretNamespace: default
+      creationPolicy: "Owner"
+      secretType: Opaque
+      template:
+        includeAllSecrets: true

--- a/apps/media/floppy/config/kustomization.yaml
+++ b/apps/media/floppy/config/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - pv.yaml
+  - infisical-floppy-secret.yaml

--- a/apps/media/floppy/config/pv.yaml
+++ b/apps/media/floppy/config/pv.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: floppy-db-pv
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  claimRef:
+    name: floppy-db-pvc
+    namespace: default
+  hostPath:
+    path: /var/local/floppy
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: floppy-db-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ""
+  volumeName: floppy-db-pv
+  resources:
+    requests:
+      storage: 5Gi

--- a/apps/media/floppy/values.yaml
+++ b/apps/media/floppy/values.yaml
@@ -10,7 +10,7 @@ controllers:
       main:
         image:
           repository: ghcr.io/dannyvfilms/floppy
-          tag: v26.8.6
+          tag: pr-685
           pullPolicy: IfNotPresent
         env:
           - name: TZ

--- a/apps/media/floppy/values.yaml
+++ b/apps/media/floppy/values.yaml
@@ -1,0 +1,101 @@
+defaultPodOptions:
+  automountServiceAccountToken: false
+
+controllers:
+  main:
+    pod:
+      annotations:
+        secret.reloader.stakater.com/reload: "infisical-floppy-secret"
+    containers:
+      main:
+        image:
+          repository: ghcr.io/dannyvfilms/floppy
+          tag: v26.8.6
+          pullPolicy: IfNotPresent
+        env:
+          - name: TZ
+            value: Europe/Chisinau
+          # Redis runs as a sidecar in this same pod (see below).
+          - name: REDIS_URL
+            value: redis://localhost:6379
+          # Public origin for ALLOWED_HOSTS / CSRF trusted origins behind Traefik.
+          - name: URLS
+            value: https://floppy.hobroker.me
+          # Needed to create the first account. Set to "false" and re-sync once
+          # your account exists to close public signups.
+          - name: REGISTRATION
+            value: "true"
+          - name: SECRET
+            valueFrom:
+              secretKeyRef:
+                name: infisical-floppy-secret
+                key: SECRET
+          - name: TMDB_API
+            valueFrom:
+              secretKeyRef:
+                name: infisical-floppy-secret
+                key: TMDB_API
+          - name: TVDB_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: infisical-floppy-secret
+                key: TVDB_API_KEY
+      redis:
+        image:
+          repository: redis
+          tag: 8-alpine
+          pullPolicy: IfNotPresent
+        # Ephemeral cache / session store on an emptyDir, so keep persistence
+        # off and cap memory with an LRU eviction policy (mirrors upstream compose).
+        args:
+          - --maxmemory
+          - 256mb
+          - --maxmemory-policy
+          - volatile-lru
+          - --save
+          - ""
+          - --appendonly
+          - "no"
+        # Sidecar has no service port; skip the chart's default port-based probes.
+        probes:
+          liveness:
+            enabled: false
+          readiness:
+            enabled: false
+          startup:
+            enabled: false
+
+service:
+  main:
+    controller: main
+    type: ClusterIP
+    ports:
+      http:
+        port: 8000
+
+persistence:
+  db:
+    existingClaim: floppy-db-pvc
+    advancedMounts:
+      main:
+        main:
+          - path: /floppy/db
+  redis:
+    type: emptyDir
+    advancedMounts:
+      main:
+        redis:
+          - path: /data
+
+ingress:
+  main:
+    enabled: true
+    annotations:
+      traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    hosts:
+      - host: floppy.hobroker.me
+        paths:
+          - path: /
+            pathType: Prefix
+            service:
+              identifier: main

--- a/apps/media/floppy/values.yaml
+++ b/apps/media/floppy/values.yaml
@@ -21,6 +21,12 @@ controllers:
           # Public origin for ALLOWED_HOSTS / CSRF trusted origins behind Traefik.
           - name: URLS
             value: https://floppy.hobroker.me
+          # In-cluster service names for internal webhook callers that reach the
+          # pod directly as http://floppy:8000 (bypassing the zero-auth proxy on
+          # the public URL). Without this Django rejects them with DisallowedHost.
+          # The app auto-appends localhost/127.0.0.1 and the URLS host on top.
+          - name: ALLOWED_HOSTS
+            value: floppy,floppy.default,floppy.default.svc.cluster.local
           # Needed to create the first account. Set to "false" and re-sync once
           # your account exists to close public signups.
           - name: REGISTRATION


### PR DESCRIPTION
### Summary

Adds [Floppy](https://github.com/dannyvfilms/Floppy) — a self-hosted all-in-one media tracker (Trakt alternative) — deployed via the `bjw-s-labs/app-template` chart.

This replaces the closed PlexTraktSync PR (#333): Trakt no longer lets free accounts create API applications, so a Trakt-based sync is no longer viable. Floppy tracks movies, TV, anime, manga, games, books, music, and podcasts directly instead.

**New files under `apps/media/floppy/`:**

- `values.yaml` — Floppy `ghcr.io/dannyvfilms/floppy:v26.8.6` on port 8000, with a **Redis `8-alpine` sidecar in the same pod** (`REDIS_URL=redis://localhost:6379`). Redis uses an ephemeral `emptyDir` cache with an LRU cap and has its default probes disabled (no service port). `SECRET`/`TMDB_API`/`TVDB_API_KEY` are injected from Infisical; `URLS`, `TZ`, and `REGISTRATION` are set inline.
- `application.yaml` — ArgoCD Application, media category, manual sync (`syncPolicy: {}`).
- `config/pv.yaml` — hostPath PV + PVC at `/var/local/floppy` mounted at `/floppy/db` (SQLite database).
- `config/infisical-floppy-secret.yaml` — Infisical secret scoped to `/floppy` (`kira`/`prod`).
- `config/kustomization.yaml`, `README.md`.
- Root `README.md` apps table regenerated via `npm run generate`.

**Required Infisical secrets (`/floppy`):**

| Key | Description |
|---|---|
| `SECRET` | Django secret key |
| `TMDB_API` | TMDB (themoviedb.org) API key |
| `TVDB_API_KEY` | TVDB (thetvdb.com) API key |

**Before deploying:**

- Create the `/floppy` Infisical secrets first, or the pod will CrashLoop.
- `REGISTRATION` is committed as `"true"` so the first account can be created — flip it to `"false"` and re-sync afterward, since the ingress is internet-facing.

Verified locally: `format:check`, `lint`, `npm run generate -- --check`, and `kubeconform` (4/4 manifests valid) all pass.

### Type

- [x] New app
- [ ] App update (version bump / config change)
- [ ] Bug fix
- [ ] Other

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxBjH8oL6Ph2UC72LUUzMJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Floppy media application to the Apps catalog.
  * Added deployment configuration with HTTPS access, persistent database storage, and Redis support.
  * Added secure production secret synchronization and application configuration.
  * Added installation and configuration documentation, including storage, metadata, and account-registration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->