### PR TITLE
docs: fix Infisical project, document Semantic PR check, clarify sync mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,22 +18,11 @@ npm run generate -- --check  # verify README is up-to-date (used in CI)
 
 ## Repo Structure
 
-```text
-apps/
-  <category>/        # automation, backup, development, media, monitoring, network, system
-    <app-name>/
-      application.yaml   # ArgoCD Application manifest
-      values.yaml        # Helm values overrides (bjw-s-labs/app-template chart)
-      README.md          # parsed by doc generator — must follow strict format
-      config/
-        pv.yaml                        # PersistentVolume (hostPath)
-        infisical-<app>-secret.yaml    # secret reference via Infisical operator
-packages/
-  catalog/            # TypeScript CLI that generates the apps table in README.md
-.github/workflows/
-  ci.yml             # lint + typecheck + test + kubeconform manifest validation
-  docs.yml           # checks npm run generate is up-to-date
-```
+- `apps/<category>/<app>/` — one dir per app: `application.yaml` (ArgoCD), `values.yaml` (Helm), `README.md` (doc-generator input), optional `config/` (PVs, Infisical secrets, kustomization).
+- `packages/catalog/` — TypeScript CLI that generates the apps table in `README.md`.
+- `.github/workflows/` — `ci.yml` (lint/typecheck/test/kubeconform), `docs.yml` (README up-to-date check).
+
+See `CONTRIBUTING.md` § "Project Structure" for the full tree and the list of categories.
 
 ## App README Format
 
@@ -61,7 +50,7 @@ or `npm run generate` will log an error and may produce incorrect output.
 
 - **Never edit the `## Apps` table in `README.md` directly** — it is auto-generated. Run `npm run generate` instead, or let the pre-commit hook do it.
 - **App README name must match directory name exactly** — the name in backticks on line 1 must equal the folder name or the catalog generator will log an error and may produce incorrect output.
-- **ArgoCD sync is manual by default** — sync is manual unless `syncPolicy.automated` is present; pushing changes does not auto-deploy without it. `syncOptions` (e.g. `CreateNamespace=true`, `ServerSideApply=true`, as in the `CONTRIBUTING.md` template) are orthogonal — they tune _how_ a sync applies, not _whether_ it runs, so a manual app may carry them and `syncPolicy: {}` is equally valid. See ArgoCD Workflow section below.
+- **ArgoCD sync is manual by default** — sync is manual unless `syncPolicy.automated` is present; `syncOptions` (`CreateNamespace`, `ServerSideApply`) don't change that. See the ArgoCD Workflow section below, and `CONTRIBUTING.md` § "Adding a new App" for how `syncOptions` relate to sync mode.
 - **Secrets must exist in Infisical before deploying** — deploying an app before its Infisical secret is created will cause CrashLoopBackOff.
 
 ## ArgoCD Workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,8 @@ kubectl get secret -n default            # list secrets
 1. Create `apps/<category>/<app-name>/` with `application.yaml`, `values.yaml`, and `README.md` (add `config/` if the app needs extra manifests like PVs or Infisical secrets)
 2. Follow the README format above exactly
 3. Run `npm run generate` to update the main README (or let the pre-commit hook do it)
-4. Run `npm run lint` and `npm run format` before committing
-5. See `CONTRIBUTING.md` for full details and the `application.yaml` template
+4. Before committing, run the same checks as CI: `npm run lint`, `npm run format`, `npm run typecheck`, `npm run test`, `npm run generate -- --check`
+5. See `CONTRIBUTING.md` for full details and the file templates
 
 ## CI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ or `npm run generate` will log an error and may produce incorrect output.
 
 - **Never edit the `## Apps` table in `README.md` directly** — it is auto-generated. Run `npm run generate` instead, or let the pre-commit hook do it.
 - **App README name must match directory name exactly** — the name in backticks on line 1 must equal the folder name or the catalog generator will log an error and may produce incorrect output.
-- **ArgoCD sync is manual by default** — no `automated:` block in `syncPolicy` means pushing changes does not auto-deploy. See ArgoCD Workflow section below.
+- **ArgoCD sync is manual by default** — sync is manual unless `syncPolicy.automated` is present; pushing changes does not auto-deploy without it. `syncOptions` (e.g. `CreateNamespace=true`, `ServerSideApply=true`, as in the `CONTRIBUTING.md` template) are orthogonal — they tune _how_ a sync applies, not _whether_ it runs, so a manual app may carry them and `syncPolicy: {}` is equally valid. See ArgoCD Workflow section below.
 - **Secrets must exist in Infisical before deploying** — deploying an app before its Infisical secret is created will cause CrashLoopBackOff.
 
 ## ArgoCD Workflow
@@ -81,7 +81,7 @@ The Kubernetes Secret name is referenced in `values.yaml` under `controllers.mai
 
 Before deploying a new app:
 
-1. Add the required secrets to Infisical (project: selfhosted)
+1. Add the required secrets to Infisical (project slug `kira`, env `prod`) under the `/<app>` path
 2. Create `config/infisical-<app>-secret.yaml`
 3. Apply it: `kubectl apply -f apps/<cat>/<app>/config/infisical-<app>-secret.yaml`
 
@@ -113,3 +113,8 @@ CI runs on every PR:
 - TypeScript type-check
 - Vitest tests
 - Kubeconform validates all YAML manifests against Kubernetes OpenAPI schemas
+
+Separately, a **Semantic PR** status check requires the **PR title** to be a
+conventional-commit summary (e.g. `feat(<app>): add <app>`, `fix(<app>): …`,
+`chore(<app>): …`). It is enforced on the title only (`.github/semantic.yml`),
+not on individual commits — a non-conventional title fails the check.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ packages/
 apps/<category>/<app-name>/
 ```
 
-Use an existing category (`automation`, `backup`, `development`, `media`, `monitoring`, `network`, `system`) or add a new one.
+Use an existing category (listed under Project Structure above) or add a new one.
 
 ### 2. Add the required files
 
@@ -74,7 +74,11 @@ spec:
 > runs, so the app above still syncs manually. Omit them (`syncPolicy: {}`) if
 > you don't need them — both stay manual.
 
-**`values.yaml`** — your Helm values overrides.
+**`values.yaml`** — your Helm values overrides for the `app-template` chart
+(`controllers`, `containers`, `service`, `persistence`, `ingress`, …). See the
+[app-template docs](https://bjw-s-labs.github.io/helm-charts/docs/app-template/)
+and the [fully-commented values reference](https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml)
+for every option, and any existing app under `apps/` for a working example.
 
 **`README.md`** — must follow the format below exactly, as it is parsed by the doc generator.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,11 @@ spec:
       - ServerSideApply=true
 ```
 
+> **Sync mode:** ArgoCD only auto-syncs when a `syncPolicy.automated` block is
+> present. The `syncOptions` above tune _how_ a sync applies, not _whether_ it
+> runs, so the app above still syncs manually. Omit them (`syncPolicy: {}`) if
+> you don't need them — both stay manual.
+
 **`values.yaml`** — your Helm values overrides.
 
 **`README.md`** — must follow the format below exactly, as it is parsed by the doc generator.
@@ -102,6 +107,10 @@ This also runs automatically as a pre-commit hook whenever a `apps/**/README.md`
 3. Make your changes
 4. Run `npm run lint` and `npm run format` to ensure consistent style
 5. Push your branch and open a PR targeting `master`
+
+Give the PR a **conventional-commit title** (e.g. `feat(<app>): add <app>`,
+`fix(<app>): …`, `chore(<app>): …`) — the **Semantic PR** check validates the
+title and fails the PR otherwise.
 
 ## Keeping Docs in Sync
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,10 @@ apps/
       application.yaml  # ArgoCD Application manifest
       values.yaml       # Helm values overrides (bjw-s-labs/app-template chart)
       README.md         # Install instructions, secrets, host volumes — parsed by the doc generator
-      config/           # Optional: extra manifests, applied via kustomize
+      config/           # Optional: extra manifests (ArgoCD applies this dir)
         pv.yaml                        # PersistentVolume (hostPath)
         infisical-<app>-secret.yaml    # secret reference via the Infisical operator
-        kustomization.yaml             # lists the config/ manifests
+        kustomization.yaml             # optional: only if you use kustomize to apply config/
 packages/
   catalog/              # TypeScript CLI that generates the apps table in the main README.md
 .github/workflows/
@@ -52,7 +52,7 @@ spec:
       path: apps/<category>/<app-name>/config
     - repoURL: https://bjw-s-labs.github.io/helm-charts
       chart: app-template
-      targetRevision: <version>
+      targetRevision: 5.0.1 # match existing apps
       helm:
         valueFiles:
           - $values/apps/<category>/<app-name>/values.yaml
@@ -111,7 +111,9 @@ This also runs automatically as a pre-commit hook whenever a `apps/**/README.md`
 1. Fork the repo and clone your fork
 2. Create a branch from `master`
 3. Make your changes
-4. Run `npm run lint` and `npm run format` to ensure consistent style
+4. Run the same checks CI does: `npm run lint`, `npm run format`,
+   `npm run typecheck`, `npm run test`, and `npm run generate -- --check`
+   (manifests are additionally validated with kubeconform in CI)
 5. Push your branch and open a PR targeting `master`
 
 Give the PR a **conventional-commit title** (e.g. `feat(<app>): add <app>`,
@@ -120,4 +122,4 @@ title and fails the PR otherwise.
 
 ## Keeping Docs in Sync
 
-If you change the app README format, categories, or PR process in this file, also update `CLAUDE.md` — it duplicates some of this information for AI assistant context.
+If you change the app README format, categories, or PR process in this file, also check `CLAUDE.md` — it summarizes and links to this information for AI assistant context.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,84 @@ spec:
 
 **`README.md`** — must follow the format below exactly, as it is parsed by the doc generator.
 
+**`config/` (optional)** — extra manifests for apps that need a host volume or
+secrets. ArgoCD applies everything in this directory.
+
+`config/pv.yaml` — a hostPath `PersistentVolume` + `PersistentVolumeClaim`. App
+config/db lives at `/var/local/<app-name>`; media/NAS volumes instead use NFS to
+`/mnt/nebula`. The PVC binds the PV by `volumeName`:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: <app-name>-config-pv
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  hostPath:
+    path: /var/local/<app-name>
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: <app-name>-config-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ""
+  volumeName: <app-name>-config-pv
+  resources:
+    requests:
+      storage: 1Gi
+```
+
+`config/infisical-<app-name>-secret.yaml` — maps Infisical secrets (project slug
+`kira`, env `prod`, path `/<app-name>`) into a Kubernetes Secret. Reference the
+resulting secret from `values.yaml` via `env[].valueFrom.secretKeyRef`. The
+secrets must already exist in Infisical, or the pod will CrashLoopBackOff:
+
+```yaml
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: infisical-<app-name>-secret
+  namespace: default
+spec:
+  resyncInterval: 60
+  authentication:
+    universalAuth:
+      secretsScope:
+        projectSlug: kira
+        envSlug: prod
+        secretsPath: "/<app-name>"
+        recursive: true
+      credentialsRef:
+        secretName: universal-auth-credentials
+        secretNamespace: infisical-operator-system
+  managedKubeSecretReferences:
+    - secretName: infisical-<app-name>-secret
+      secretNamespace: default
+      creationPolicy: "Owner"
+      secretType: Opaque
+      template:
+        includeAllSecrets: true
+```
+
+`config/kustomization.yaml` — only needed if you apply `config/` with kustomize:
+
+```yaml
+resources:
+  - pv.yaml
+  - infisical-<app-name>-secret.yaml
+```
+
 ### 3. App README format
 
 The doc generator reads three fields from each app's `README.md`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,20 @@
 
 ```
 apps/
-  <category>/
+  <category>/           # automation, backup, development, media, monitoring, network, system
     <app>/
       application.yaml  # ArgoCD Application manifest
-      values.yaml       # Helm values overrides
-      README.md         # Install instructions, secrets, host volumes
-      config/           # Optional: extra manifests (PVs, Infisical secrets, etc.)
+      values.yaml       # Helm values overrides (bjw-s-labs/app-template chart)
+      README.md         # Install instructions, secrets, host volumes — parsed by the doc generator
+      config/           # Optional: extra manifests, applied via kustomize
+        pv.yaml                        # PersistentVolume (hostPath)
+        infisical-<app>-secret.yaml    # secret reference via the Infisical operator
+        kustomization.yaml             # lists the config/ manifests
 packages/
-  catalog/              # Generates the apps table in the main README.md
+  catalog/              # TypeScript CLI that generates the apps table in the main README.md
+.github/workflows/
+  ci.yml                # lint + typecheck + test + kubeconform manifest validation
+  docs.yml              # checks `npm run generate` output is up to date
 ```
 
 ## Adding a new App


### PR DESCRIPTION
### Summary

Documentation improvements for `CLAUDE.md` and `CONTRIBUTING.md` — correctness fixes, a dedup pass so the two files stop drifting, and making CONTRIBUTING self-contained as the app-authoring guide.

**Correctness fixes**

1. **Infisical project name was wrong.** `CLAUDE.md` said "project: selfhosted", but every `InfisicalSecret` manifest uses `projectSlug: kira` / `envSlug: prod`. Corrected to project slug `kira`, env `prod`, under `/<app>`.
2. **Semantic PR check was undocumented.** `.github/semantic.yml` (`titleOnly: true`) requires a conventional-commit PR title. Documented in both files.
3. **`syncPolicy` guidance was ambiguous.** Clarified that auto-sync depends solely on a `syncPolicy.automated` block; `syncOptions` (`CreateNamespace`, `ServerSideApply`) are orthogonal.

**Deduplication (single-sourcing)**

4. Ownership split so facts live in one place: **CONTRIBUTING.md** owns authoring mechanics (full project tree, category list, `syncPolicy` explanation); **CLAUDE.md** keeps operational/AI context and links to CONTRIBUTING instead of restating (Repo Structure and the `syncPolicy` gotcha trimmed to summary + pointer). Same drift class that caused fix #1.

**CONTRIBUTING completeness**

5. Small clarity fixes: pinned the template chart to `5.0.1`, listed the full pre-PR check set (lint/format/typecheck/test/generate --check), marked `kustomization.yaml` optional, reworded the docs-sync note.
6. Added copy-ready templates for the optional `config/` files — `pv.yaml` (hostPath PV + PVC, dominant `volumeName` binding), `infisical-<app>-secret.yaml` (Infisical → K8s Secret, `kira`/`prod`), and `kustomization.yaml` — so adding an app that needs storage or secrets no longer requires copying from an existing app.

Docs-only — no manifest or code changes. Prettier passes.

### Type

- [ ] New app
- [ ] App update (version bump / config change)
- [ ] Bug fix
- [x] Other

🤖 Generated with [Claude Code](https://claude.com/claude-code)