### PR TITLE
fix(media): add missing service ports for fileflows and threadfin

### DIFF
--- a/apps/media/fileflows/values.yaml
+++ b/apps/media/fileflows/values.yaml
@@ -23,6 +23,9 @@ service:
   main:
     controller: main
     type: ClusterIP
+    ports:
+      http:
+        port: 5000
 
 persistence:
   config:

--- a/apps/media/threadfin/values.yaml
+++ b/apps/media/threadfin/values.yaml
@@ -14,6 +14,9 @@ service:
   main:
     controller: main
     type: ClusterIP
+    ports:
+      http:
+        port: 34400
 
 persistence:
   config:


### PR DESCRIPTION
## What

`fileflows` and `threadfin` each declared a `service.main` of type `ClusterIP` with **no `ports`**. The bjw-s `app-template` chart hard-fails on this at render time:

```
Service 'main': No ports are enabled. At least one port must be enabled for
service type 'ClusterIP'. Add ports under 'services.main.ports' in your values.
```

Because the chart never renders, neither app can sync — confirmed against the live cluster: **neither `fileflows` nor `threadfin` exists in ArgoCD**, while the other 23 apps are deployed. `fileflows` additionally routes an `ingress` at that portless service.

## Fix

Add the upstream default web ports so the chart renders:

| app | port | source |
|-----|------|--------|
| fileflows | `5000` | FileFlows web UI (`revenz/fileflows`) |
| threadfin | `34400` | Threadfin web UI (`fyb3roptik/threadfin`) |

> Please sanity-check the port values against your intended setup — these apps aren't currently deployed, so the ports are the documented upstream defaults rather than something verified against a running instance.

## Verification

Rendered both through `app-template` 5.0.1 and validated with kubeconform (same schema locations as the `kubeconform` CI job):

```
==> fileflows  Valid: 4, Invalid: 0, Errors: 0
==> threadfin  Valid: 3, Invalid: 0, Errors: 0
```

## Context

Surfaced by a follow-up CI check (helm-template + kubeconform over every app-template `values.yaml`), which lands stacked on top of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP service access for FileFlows on port 5000.
  * Added HTTP service access for Threadfin on port 34400.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->