### PR TITLE
ci: render app-template values and validate with kubeconform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,16 @@ jobs:
             -schema-location default \
             -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
             -summary
+
+  helm-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: yokawasa/action-setup-kube-tools@v0.14.0
+        with:
+          kubeconform: "0.7.0"
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+      - name: Render app-template values and validate
+        run: ./scripts/helm-validate.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
           kubeconform: "0.7.0"
       - uses: azure/setup-helm@v4
         with:
-          version: v3.16.4
+          # Match the Helm bundled in ArgoCD's repo-server (argocd v3.4.6 ships
+          # Helm v3.19.4) so CI renders charts the same way sync does.
+          version: v3.19.4
       - name: Render app-template values and validate
         run: ./scripts/helm-validate.sh

--- a/scripts/helm-validate.sh
+++ b/scripts/helm-validate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Render every bjw-s app-template app's values.yaml and validate the rendered
+# manifests with kubeconform. Catches broken values.yaml that the raw-manifest
+# kubeconform job can't see (it never renders the chart).
+set -uo pipefail
+
+CATALOG='https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+
+helm repo add bjw-s https://bjw-s-labs.github.io/helm-charts >/dev/null 2>&1 || true
+helm repo update bjw-s >/dev/null
+
+fail=0
+while IFS= read -r values; do
+  app_yaml="$(dirname "$values")/application.yaml"
+  grep -q 'chart: app-template' "$app_yaml" 2>/dev/null || continue
+  name="$(basename "$(dirname "$values")")"
+  version="$(grep -A2 'chart: app-template' "$app_yaml" | grep 'targetRevision:' | head -1 | awk '{print $2}')"
+  if [ -z "$version" ]; then
+    echo "::error file=$app_yaml::could not parse app-template targetRevision for $name"
+    fail=1
+    continue
+  fi
+  echo "==> $name (app-template $version)"
+  if ! helm template "$name" bjw-s/app-template --version "$version" -f "$values" \
+       | kubeconform -summary -schema-location default -schema-location "$CATALOG" -; then
+    echo "::error file=$values::helm template + kubeconform failed for $name"
+    fail=1
+  fi
+done < <(find apps -name values.yaml | sort)
+
+exit $fail


### PR DESCRIPTION
## Problem

The existing `kubeconform` job only validates raw YAML files containing `kind:` — it never renders the Helm chart. A structurally broken `values.yaml` (wrong sidecar, mount, probe, or service shape) sails through CI and only fails later at ArgoCD sync. This check closes that gap.

It already earned its keep: on the first run it caught two apps (`fileflows`, `threadfin`) whose `service.main` had no ports and which therefore were never deployed. Those are fixed in the PR this one is stacked on (#336).

## What it does

`scripts/helm-validate.sh`:

- Finds every app whose `application.yaml` has `chart: app-template` (23–24 apps; the 8 system-operator / prometheus-operator apps use other charts and are skipped).
- Reads each app's chart version from `targetRevision` in `application.yaml` (all `5.0.1` today) and fails loudly if it can't be parsed.
- Runs `helm template … | kubeconform` with the **same** schema locations as the existing `kubeconform` job (`default` + the datreeio CRDs-catalog URL). No `-ignore-missing-schemas` needed — `ServiceMonitor` (scraparr, radarr) resolves via the catalog.
- Uses `set -o pipefail` so a `helm template` failure isn't masked by kubeconform returning `0` on empty stdin.
- Emits a GitHub `::error file=…::` annotation per failing app and exits non-zero.

A new `helm-validate` CI job installs kubeconform + helm and runs it.

## Verification

**Positive** — all app-template apps render + validate cleanly (exit 0), e.g.:

```
==> radarr (app-template 5.0.1)
Summary: 5 resources found parsing stdin - Valid: 5, Invalid: 0, Errors: 0, Skipped: 0
```

**Negative** — temporarily set `radarr` `service.main.ports.http.port: "not-a-number"`:

```
==> radarr (app-template 5.0.1)
stdin - Service radarr is invalid: ... at '/spec/ports/0/port': got string, want integer
::error file=apps/media/radarr/values.yaml::helm template + kubeconform failed for radarr
SCRIPT EXIT CODE: 1
```

Reverted after. `shellcheck` clean; `npm run format:check` and `npm run lint` pass.

## ⚠️ Note for reviewers — runs only with network egress

This check needs to reach `bjw-s-labs.github.io` (chart repo) and `get.helm.sh` (helm install). It works in GitHub Actions and in a local run with network access, but **Claude Code *web* sessions cannot run it** — their egress proxy blocks those hosts. To validate it in a web session, those hosts would need allowlisting; otherwise a maintainer/local run is the way to exercise it. (This PR was tested locally against a live cluster.)

## Stacking

Based on `fix/fileflows-threadfin-service-ports` (#336) so its own CI is green. GitHub will auto-retarget this PR to `master` once #336 merges; if #336 is squash-merged, rebase this branch onto `master` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)