### PR TITLE
feat(argocd): order system apps via app-of-apps + README overhaul

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           kubeconform: "0.7.0"
       - name: Validate manifests
         run: |
-          grep -rlE --include='*.yaml' 'kind:' apps | xargs kubeconform \
+          grep -rlE --include='*.yaml' 'kind:' apps bootstrap | xargs kubeconform \
             -schema-location default \
             -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
             -summary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ or `npm run generate` will log an error and may produce incorrect output.
 3. Sync manually: ArgoCD UI → app → Sync, or: `argocd app sync <app-name>`
 4. To watch rollout: `kubectl rollout status deploy/<app> -n default`
 
-System apps (argocd, traefik, cert-manager, metallb) use sync-waves and should be deployed first.
+System apps (metallb, longhorn, traefik, infisical-operator, reloader, rancher) use sync-waves and should be deployed first.
 
 ## Secrets (Infisical)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ npm run generate -- --check  # verify README is up-to-date (used in CI)
 ## Repo Structure
 
 - `apps/<category>/<app>/` — one dir per app: `application.yaml` (ArgoCD), `values.yaml` (Helm), `README.md` (doc-generator input), optional `config/` (PVs, Infisical secrets, kustomization).
+- `bootstrap/system.yaml` — root app-of-apps that deploys the `apps/system` apps in sync-wave order.
 - `packages/catalog/` — TypeScript CLI that generates the apps table in `README.md`.
 - `.github/workflows/` — `ci.yml` (lint/typecheck/test/kubeconform), `docs.yml` (README up-to-date check).
 
@@ -43,14 +44,14 @@ or `npm run generate` will log an error and may produce incorrect output.
 - **Secrets**: Injected via [Infisical operator](https://infisical.com/docs/integrations/platforms/kubernetes). Each app has an `infisical-<app>-secret.yaml` in `config/`.
 - **Storage**: Default host paths are `/var/local/<app>` (config/db) and `/mnt/nebula` (media/NAS). StorageClass uses `Retain` reclaim policy.
 - **Ingress**: All apps use Traefik. Domain pattern: `<app>.hobroker.me`.
-- **ArgoCD sync**: `syncPolicy: {}` means manual sync by default. System apps use sync-waves for ordering.
+- **ArgoCD sync**: workload apps are manual-sync (`syncPolicy: {}`) by default. System apps set `syncPolicy.automated` and are deployed in sync-wave order by the root app-of-apps (`bootstrap/system.yaml`).
 - **Auto-generated content**: The `## Apps` section in `README.md` is auto-generated. Never edit it manually — always run `npm run generate`.
 
 ## Gotchas
 
 - **Never edit the `## Apps` table in `README.md` directly** — it is auto-generated. Run `npm run generate` instead, or let the pre-commit hook do it.
 - **App README name must match directory name exactly** — the name in backticks on line 1 must equal the folder name or the catalog generator will log an error and may produce incorrect output.
-- **ArgoCD sync is manual by default** — sync is manual unless `syncPolicy.automated` is present; `syncOptions` (`CreateNamespace`, `ServerSideApply`) don't change that. See the ArgoCD Workflow section below, and `CONTRIBUTING.md` § "Adding a new App" for how `syncOptions` relate to sync mode.
+- **ArgoCD sync is manual by default** — sync is manual unless `syncPolicy.automated` is present; `syncOptions` (`CreateNamespace`, `ServerSideApply`) don't change that. System apps are the exception: they set `automated` and are ordered by the root app-of-apps (`bootstrap/system.yaml`). See the ArgoCD Workflow section below, and `CONTRIBUTING.md` § "Adding a new App" for how `syncOptions` relate to sync mode.
 - **Secrets must exist in Infisical before deploying** — deploying an app before its Infisical secret is created will cause CrashLoopBackOff.
 
 ## ArgoCD Workflow
@@ -60,7 +61,7 @@ or `npm run generate` will log an error and may produce incorrect output.
 3. Sync manually: ArgoCD UI → app → Sync, or: `argocd app sync <app-name>`
 4. To watch rollout: `kubectl rollout status deploy/<app> -n default`
 
-System apps (metallb, longhorn, traefik, infisical-operator, reloader, rancher) use sync-waves and should be deployed first.
+System apps (metallb, longhorn, traefik, infisical-operator, reloader, rancher) auto-sync in sync-wave order via the root app-of-apps (`bootstrap/system.yaml`) and come up before workload apps. Apply it once after bootstrapping ArgoCD: `kubectl apply -f bootstrap/system.yaml`.
 
 ## Secrets (Infisical)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ or `npm run generate` will log an error and may produce incorrect output.
 3. Sync manually: ArgoCD UI → app → Sync, or: `argocd app sync <app-name>`
 4. To watch rollout: `kubectl rollout status deploy/<app> -n default`
 
-System apps (metallb, longhorn, traefik, infisical-operator, reloader, rancher) auto-sync in sync-wave order via the root app-of-apps (`bootstrap/system.yaml`) and come up before workload apps. Apply it once after bootstrapping ArgoCD: `kubectl apply -f bootstrap/system.yaml`.
+System apps (metallb, longhorn, traefik, infisical-operator, reloader) auto-sync in sync-wave order via the root app-of-apps (`bootstrap/system.yaml`) and come up before workload apps. Apply it once after bootstrapping ArgoCD: `kubectl apply -f bootstrap/system.yaml`. (argocd and rancher are excluded — deployed manually.)
 
 ## Secrets (Infisical)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ apps/
         pv.yaml                        # PersistentVolume (hostPath)
         infisical-<app>-secret.yaml    # secret reference via the Infisical operator
         kustomization.yaml             # optional: only if you use kustomize to apply config/
+bootstrap/
+  system.yaml           # root app-of-apps: deploys apps/system in sync-wave order
 packages/
   catalog/              # TypeScript CLI that generates the apps table in the main README.md
 .github/workflows/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,14 @@ spec:
 > runs, so the app above still syncs manually. Omit them (`syncPolicy: {}`) if
 > you don't need them — both stay manual.
 
+> **System apps are different:** anything under `apps/system/` is auto-discovered
+> by the root app-of-apps ([`bootstrap/system.yaml`](bootstrap/system.yaml)) via
+> its `*/application.yaml` glob. To slot a new system app into the ordered
+> bring-up, give it both `syncPolicy.automated: {}` and an
+> `argocd.argoproj.io/sync-wave` annotation (choose a wave relative to the
+> existing ones). To keep it out of the wave and deploy it manually — like
+> `argocd` and `rancher` — add it to the root's `exclude` instead.
+
 **`values.yaml`** — your Helm values overrides for the `app-template` chart
 (`controllers`, `containers`, `service`, `persistence`, `ingress`, …). See the
 [app-template docs](https://bjw-s-labs.github.io/helm-charts/docs/app-template/)

--- a/README.md
+++ b/README.md
@@ -110,14 +110,21 @@ Not using ArgoCD? You can install any app directly with Helm (`helm upgrade --in
 
 ## System App Order
 
-System apps must be synced before any other apps. ArgoCD sync-wave annotations handle ordering automatically when syncing all at once. If syncing manually, use this order:
+System apps must be running before any workload apps. A root **app-of-apps** ([`bootstrap/system.yaml`](bootstrap/system.yaml)) handles this — apply it once and ArgoCD deploys every system app in [sync-wave](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/) order, waiting for each wave to become healthy before starting the next:
+
+```sh
+kubectl apply -f bootstrap/system.yaml
+```
+
+The resulting order (apps in the same wave deploy in parallel):
 
 1. [metallb](apps/system/metallb) — load balancer (assigns external IPs)
-2. [longhorn](apps/system/longhorn) — persistent storage
-3. [traefik](apps/system/traefik) — ingress / reverse proxy
-4. [infisical-operator](apps/system/infisical-operator) — secret injection
-5. [reloader](apps/system/reloader) — rolling restarts on config/secret changes
-6. Apps (any order)
+2. [longhorn](apps/system/longhorn) · [traefik](apps/system/traefik) — persistent storage + ingress
+3. [infisical-operator](apps/system/infisical-operator) — secret injection
+4. [reloader](apps/system/reloader) — rolling restarts on config/secret changes
+5. [rancher](apps/system/rancher) — cluster management UI
+
+> The system apps set `syncPolicy.automated` so the app-of-apps can drive them in order; workload apps stay manual-sync by default. ArgoCD itself ([apps/system/argocd](apps/system/argocd)) is bootstrapped separately and manages itself.
 
 ## Host Directories
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Run your own media server, backups, monitoring, automation, and more — on hard
 
 ## Overview
 
-**31 self-hosted apps across 7 categories**, all deployed the same way — one Helm chart plus GitOps. The stack:
+**<!-- stats:start -->31 self-hosted apps across 7 categories<!-- stats:end -->**, all deployed the same way — one Helm chart plus GitOps. The stack:
 
 - **[Kubernetes](https://kubernetes.io/)** — runs everything (distribution-agnostic: Talos, k3s, …)
 - **[bjw-s app-template](https://bjw-s-labs.github.io/helm-charts/docs/app-template/)** — the single Helm chart every app is built on, so configs stay consistent

--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ cd selfhosted
 
 ### 3. Bootstrap ArgoCD (optional)
 
-ArgoCD watches this Git repo and automatically syncs changes to your cluster — no manual `helm install` needed. It also provides a web UI to monitor and manage all your deployments. See [apps/system/argocd](apps/system/argocd) for bootstrap instructions.
+ArgoCD watches this Git repo and syncs changes from it to your cluster — no manual `helm install` needed. It also provides a web UI to monitor and manage all your deployments. See [apps/system/argocd](apps/system/argocd) for bootstrap instructions.
 
 ### 4. Deploy an app
+
+> On a fresh cluster, bring up the [system apps](#system-app-order) first (storage, ingress, secrets) — workload apps depend on them.
 
 Pick an app and follow its `README.md` — each one has copy-paste commands for both ArgoCD and plain Helm. For example, to deploy [Syncthing](apps/backup/syncthing) with ArgoCD:
 

--- a/README.md
+++ b/README.md
@@ -116,11 +116,12 @@ If you're not using ArgoCD, you can deploy any app directly with `helm install` 
 
 System apps must be synced before any other apps. ArgoCD sync-wave annotations handle ordering automatically when syncing all at once. If syncing manually, use this order:
 
-1. [local-path-provisioner](apps/system/local-path-provisioner) — persistent storage class
-2. [traefik](apps/system/traefik) — ingress / reverse proxy
-3. [infisical-operator](apps/system/infisical-operator) — secret injection
-4. [reloader](apps/system/reloader) — rolling restarts on config/secret changes
-5. Apps (any order)
+1. [metallb](apps/system/metallb) — load balancer (assigns external IPs)
+2. [longhorn](apps/system/longhorn) — persistent storage
+3. [traefik](apps/system/traefik) — ingress / reverse proxy
+4. [infisical-operator](apps/system/infisical-operator) — secret injection
+5. [reloader](apps/system/reloader) — rolling restarts on config/secret changes
+6. Apps (any order)
 
 ## Host Directories
 
@@ -133,7 +134,7 @@ The defaults below reflect this homelab's setup — update them to match your ow
 
 To customize paths, edit the `config/pv.yaml` in each app you deploy.
 
-A custom `StorageClass` with a `Retain` reclaim policy is also available to prevent data loss when PVCs are deleted — see [local-path-provisioner](apps/system/local-path-provisioner).
+A `longhorn-retain` `StorageClass` with a `Retain` reclaim policy is also available to prevent data loss when PVCs are deleted — see [longhorn](apps/system/longhorn).
 
 ## Secrets
 

--- a/README.md
+++ b/README.md
@@ -122,9 +122,8 @@ The resulting order (apps in the same wave deploy in parallel):
 2. [longhorn](apps/system/longhorn) · [traefik](apps/system/traefik) — persistent storage + ingress
 3. [infisical-operator](apps/system/infisical-operator) — secret injection
 4. [reloader](apps/system/reloader) — rolling restarts on config/secret changes
-5. [rancher](apps/system/rancher) — cluster management UI
 
-> The system apps set `syncPolicy.automated` so the app-of-apps can drive them in order; workload apps stay manual-sync by default. ArgoCD itself ([apps/system/argocd](apps/system/argocd)) is bootstrapped separately and manages itself.
+> These apps set `syncPolicy.automated` so the app-of-apps can drive them in order; workload apps stay manual-sync by default. Two system apps sit outside the wave and are deployed manually: [argocd](apps/system/argocd) (bootstrapped separately, manages itself) and [rancher](apps/system/rancher) (an optional management UI).
 
 ## Host Directories
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Run your own media server, backups, monitoring, automation, and more — on hard
   - [3. Bootstrap ArgoCD (optional)](#3-bootstrap-argocd-optional)
   - [4. Deploy an app](#4-deploy-an-app)
 - [How It Works](#how-it-works)
-- [Deploy Order](#deploy-order)
+- [System App Order](#system-app-order)
 - [Host Directories](#host-directories)
 - [Secrets](#secrets)
 - [Deploying an App](#deploying-an-app)
@@ -108,7 +108,7 @@ This is simplified — real external access also depends on your DNS and (if ena
 
 Not using ArgoCD? You can install any app directly with Helm (`helm upgrade --install`) — the same `values.yaml` drives both paths.
 
-## Deploy Order
+## System App Order
 
 System apps must be synced before any other apps. ArgoCD sync-wave annotations handle ordering automatically when syncing all at once. If syncing manually, use this order:
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Every app lives in `apps/<category>/<app>/` with its own Helm values, ArgoCD man
 
 Bring up any Kubernetes cluster and export a working kubeconfig. If this is your first cluster, [k3s](https://k3s.io/) is the easiest way to start:
 
-```shell
+```sh
 curl -sfL https://get.k3s.io | sh -
 ```
 
@@ -69,7 +69,7 @@ curl -sfL https://get.k3s.io | sh -
 
 ### 2. Clone this repo
 
-```
+```sh
 git clone https://github.com/hobroker/selfhosted.git
 cd selfhosted
 ```
@@ -80,17 +80,13 @@ ArgoCD watches this Git repo and automatically syncs changes to your cluster —
 
 ### 4. Deploy an app
 
-Pick an app and follow its `README.md` — each one includes instructions for both ArgoCD and plain Helm deployment. For example, to deploy [Syncthing](apps/backup/syncthing):
+Pick an app and follow its `README.md` — each one has copy-paste commands for both ArgoCD and plain Helm. For example, to deploy [Syncthing](apps/backup/syncthing) with ArgoCD:
 
-```shell
-# With ArgoCD
+```sh
 kubectl apply -f apps/backup/syncthing/application.yaml
-
-# Or with Helm directly
-helm install syncthing apps/backup/syncthing
 ```
 
-See [Deploying an App](#deploying-an-app) for more details.
+Prefer plain Helm? Each app's README lists the exact `helm upgrade --install` commands. The apps install from the remote `app-template` chart (not a local one), so there's no `helm install <path>`. See [Deploying an App](#deploying-an-app) for details.
 
 ## How It Works
 
@@ -106,11 +102,11 @@ flowchart LR
     traefik -->|routes by domain| apps
 ```
 
-Most apps are packaged as Helm charts. ArgoCD watches this repo and continuously syncs chart/manifests to your cluster. Traefik acts as the reverse proxy, routing incoming requests to the right app based on domain/path rules. Infisical injects secrets into pods at deploy time.
+In short: you push a change, ArgoCD applies the updated Helm charts to your cluster, and Traefik routes each incoming request to the right app by domain. Infisical injects secrets into pods at deploy time, and volumes are mounted from the host or NFS.
 
-This is a simplified flow: external access depends on your ingress config, DNS, and (if enabled) TLS setup.
+This is simplified — real external access also depends on your DNS and (if enabled) TLS setup.
 
-If you're not using ArgoCD, you can deploy any app directly with `helm install` — the Helm values work the same either way.
+Not using ArgoCD? You can install any app directly with Helm (`helm upgrade --install`) — the same `values.yaml` drives both paths.
 
 ## Deploy Order
 
@@ -134,7 +130,7 @@ The defaults below reflect this homelab's setup — update them to match your ow
 
 To customize paths, edit the `config/pv.yaml` in each app you deploy.
 
-A `longhorn-retain` `StorageClass` with a `Retain` reclaim policy is also available to prevent data loss when PVCs are deleted — see [longhorn](apps/system/longhorn).
+Longhorn also provides a `longhorn-retain` StorageClass, whose `Retain` reclaim policy keeps your data even if a PVC is deleted — see [longhorn](apps/system/longhorn).
 
 ## Secrets
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Selfhosted
 
+[![CI](https://github.com/hobroker/selfhosted/actions/workflows/ci.yml/badge.svg)](https://github.com/hobroker/selfhosted/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 Run your own media server, backups, monitoring, automation, and more — on hardware you control. This repository contains a collection of self-hosted apps, deployable on any Kubernetes cluster via [Helm](https://helm.sh/) or [ArgoCD](https://argo-cd.readthedocs.io/).
 
 > [!NOTE]
@@ -7,6 +10,7 @@ Run your own media server, backups, monitoring, automation, and more — on hard
 
 ## Table of Contents
 
+- [Overview](#overview)
 - [Prerequisites](#prerequisites)
 - [Getting Started](#getting-started)
   - [1. Set up a Kubernetes cluster](#1-set-up-a-kubernetes-cluster)
@@ -18,7 +22,6 @@ Run your own media server, backups, monitoring, automation, and more — on hard
 - [Host Directories](#host-directories)
 - [Secrets](#secrets)
 - [Deploying an App](#deploying-an-app)
-- [Docs Generation](#docs-generation)
 - [Apps](#apps)
   - [Automation](#automation)
   - [Backup](#backup)
@@ -31,13 +34,26 @@ Run your own media server, backups, monitoring, automation, and more — on hard
 - [References](#references)
 - [Contributing](#contributing)
 
+## Overview
+
+**31 self-hosted apps across 7 categories**, all deployed the same way — one Helm chart plus GitOps. The stack:
+
+- **[Kubernetes](https://kubernetes.io/)** — runs everything (distribution-agnostic: Talos, k3s, …)
+- **[bjw-s app-template](https://bjw-s-labs.github.io/helm-charts/docs/app-template/)** — the single Helm chart every app is built on, so configs stay consistent
+- **[ArgoCD](https://argo-cd.readthedocs.io/)** — GitOps controller; continuously syncs this repo to the cluster
+- **[Traefik](https://traefik.io/)** — ingress / reverse proxy (`<app>.<domain>`)
+- **[Infisical](https://infisical.com/)** — injects secrets into pods at deploy time
+- **[Reloader](https://github.com/stakater/Reloader)** — restarts pods when their config or secrets change
+
+Every app lives in `apps/<category>/<app>/` with its own Helm values, ArgoCD manifest, and README. Browse the full list under [Apps](#apps).
+
 ## Prerequisites
 
 - A Kubernetes cluster (any distribution — [Talos](https://www.talos.dev/), [k3s](https://k3s.io/), etc.)
 - [Helm](https://helm.sh/docs/intro/install/) — Kubernetes package manager
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) — Kubernetes CLI
 - [ArgoCD](https://argo-cd.readthedocs.io/en/stable/getting_started/) — optional GitOps controller (see [apps/system/argocd](apps/system/argocd))
-- [Node.js](https://nodejs.org/) + npm — optional, for [generating docs](#docs-generation)
+- [Node.js](https://nodejs.org/) + npm — optional, for regenerating the [Apps](#apps) table (see [CONTRIBUTING.md](CONTRIBUTING.md))
 
 ## Getting Started
 
@@ -78,8 +94,17 @@ See [Deploying an App](#deploying-an-app) for more details.
 
 ## How It Works
 
-> [!NOTE]
-> Git push → ArgoCD detects changes → sync applies Helm manifests to the cluster → Traefik routes traffic → App reachable
+```mermaid
+flowchart LR
+    dev([git push]) --> repo[(Git repo)]
+    repo -->|watches & syncs| argo[ArgoCD]
+    argo -->|applies Helm manifests| cluster{{Kubernetes cluster}}
+    infisical[Infisical] -. injects secrets .-> cluster
+    storage[(Host / NFS storage)] -. mounts volumes .-> cluster
+    cluster --> apps[Apps]
+    user([You]) -->|request| traefik[Traefik]
+    traefik -->|routes by domain| apps
+```
 
 Most apps are packaged as Helm charts. ArgoCD watches this repo and continuously syncs chart/manifests to your cluster. Traefik acts as the reverse proxy, routing incoming requests to the right app based on domain/path rules. Infisical injects secrets into pods at deploy time.
 
@@ -129,14 +154,6 @@ kubectl apply -f apps/<category>/<name>/application.yaml
 ```
 
 Then sync it in the ArgoCD UI or with `argocd app sync <name>`.
-
-## Docs Generation
-
-The [Apps](#apps) tables in this README are auto-generated from app metadata. To regenerate them after adding or updating an app:
-
-```shell
-npm run generate
-```
 
 ## Apps
 

--- a/apps/system/argocd/README.md
+++ b/apps/system/argocd/README.md
@@ -34,9 +34,9 @@ Once ArgoCD is running, deploy all system apps in the correct order with the roo
 kubectl apply -f bootstrap/system.yaml
 ```
 
-This creates and auto-syncs metallb, longhorn, traefik, infisical-operator, reloader, and rancher in [sync-wave](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/) order. See [System App Order](../../../README.md#system-app-order) for the waves.
+This creates and auto-syncs metallb, longhorn, traefik, infisical-operator, and reloader in [sync-wave](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/) order. See [System App Order](../../../README.md#system-app-order) for the waves.
 
-Workload apps are registered individually and synced manually:
+Workload apps (and rancher) are registered individually and synced manually:
 
 ```sh
 kubectl apply -f apps/<category>/<app>/application.yaml

--- a/apps/system/argocd/README.md
+++ b/apps/system/argocd/README.md
@@ -26,21 +26,22 @@ kubectl apply -f application.yaml
 argocd app sync argocd
 ```
 
-## Register / update the Application resourceing Services
+## Deploying the rest of the platform
 
-Each service has an `application.yaml` co-located in its chart directory. Register services individually:
+Once ArgoCD is running, deploy all system apps in the correct order with the root app-of-apps (run from the repo root):
 
 ```sh
-kubectl apply -f charts/<category>/<service>/application.yaml
+kubectl apply -f bootstrap/system.yaml
 ```
 
-Then sync via the ArgoCD UI. For system services, sync in this order:
+This creates and auto-syncs metallb, longhorn, traefik, infisical-operator, reloader, and rancher in [sync-wave](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/) order. See [System App Order](../../../README.md#system-app-order) for the waves.
 
-1. `local-path-provisioner`
-2. `traefik`
-3. `infisical-operator`
-4. `reloader` (optional)
-5. `rancher` (optional)
+Workload apps are registered individually and synced manually:
+
+```sh
+kubectl apply -f apps/<category>/<app>/application.yaml
+# then sync via the ArgoCD UI or: argocd app sync <app>
+```
 
 ## CLI Access
 

--- a/apps/system/infisical-operator/application.yaml
+++ b/apps/system/infisical-operator/application.yaml
@@ -30,6 +30,7 @@ spec:
     namespace: infisical-operator-system
   revisionHistoryLimit: 3
   syncPolicy:
+    automated: {}
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/system/longhorn/application.yaml
+++ b/apps/system/longhorn/application.yaml
@@ -28,4 +28,5 @@ spec:
     server: https://kubernetes.default.svc
     namespace: longhorn-system
   revisionHistoryLimit: 3
-  syncPolicy: {}
+  syncPolicy:
+    automated: {}

--- a/apps/system/metallb/application.yaml
+++ b/apps/system/metallb/application.yaml
@@ -37,6 +37,7 @@ spec:
       jsonPointers:
         - /spec/conversion/webhook/clientConfig/caBundle
   syncPolicy:
+    automated: {}
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/system/rancher/application.yaml
+++ b/apps/system/rancher/application.yaml
@@ -26,6 +26,7 @@ spec:
     namespace: cattle-system
   revisionHistoryLimit: 3
   syncPolicy:
+    automated: {}
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/system/rancher/application.yaml
+++ b/apps/system/rancher/application.yaml
@@ -7,8 +7,6 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
   labels:
     category: system
-  annotations:
-    argocd.argoproj.io/sync-wave: "5"
 spec:
   project: default
   sources:
@@ -26,7 +24,6 @@ spec:
     namespace: cattle-system
   revisionHistoryLimit: 3
   syncPolicy:
-    automated: {}
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/system/reloader/application.yaml
+++ b/apps/system/reloader/application.yaml
@@ -26,6 +26,7 @@ spec:
     namespace: kube-system
   revisionHistoryLimit: 3
   syncPolicy:
+    automated: {}
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/system/traefik/application.yaml
+++ b/apps/system/traefik/application.yaml
@@ -29,6 +29,7 @@ spec:
     namespace: kube-system
   revisionHistoryLimit: 3
   syncPolicy:
+    automated: {}
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/bootstrap/system.yaml
+++ b/bootstrap/system.yaml
@@ -3,10 +3,9 @@
 # Applied once after ArgoCD is bootstrapped:
 #   kubectl apply -f bootstrap/system.yaml
 #
-# It discovers every apps/system/<app>/application.yaml (except argocd, which
-# bootstraps itself) and deploys them in sync-wave order:
-#   metallb (1) -> longhorn / traefik (2) -> infisical-operator (3)
-#     -> reloader (4) -> rancher (5)
+# It discovers every apps/system/<app>/application.yaml (except argocd and
+# rancher, see excludes below) and deploys them in sync-wave order:
+#   metallb (1) -> longhorn / traefik (2) -> infisical-operator (3) -> reloader (4)
 # Ordering only holds because the child apps set syncPolicy.automated, so each
 # wave is synced and healthy before the next begins.
 apiVersion: argoproj.io/v1alpha1
@@ -27,8 +26,8 @@ spec:
       # Pick up only the per-app Application manifests — never their values.yaml,
       # config/, or postsync/. A single `*` does not cross directory levels.
       include: "*/application.yaml"
-      # argocd is bootstrapped via Helm and manages itself.
-      exclude: "argocd/application.yaml"
+      # argocd bootstraps itself; rancher is an optional UI deployed manually.
+      exclude: "{argocd/application.yaml,rancher/application.yaml}"
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/bootstrap/system.yaml
+++ b/bootstrap/system.yaml
@@ -1,0 +1,39 @@
+# Root "app-of-apps" for system infrastructure.
+#
+# Applied once after ArgoCD is bootstrapped:
+#   kubectl apply -f bootstrap/system.yaml
+#
+# It discovers every apps/system/<app>/application.yaml (except argocd, which
+# bootstraps itself) and deploys them in sync-wave order:
+#   metallb (1) -> longhorn / traefik (2) -> infisical-operator (3)
+#     -> reloader (4) -> rancher (5)
+# Ordering only holds because the child apps set syncPolicy.automated, so each
+# wave is synced and healthy before the next begins.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: system
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/hobroker/selfhosted.git
+    targetRevision: HEAD
+    path: apps/system
+    directory:
+      recurse: true
+      # Pick up only the per-app Application manifests — never their values.yaml,
+      # config/, or postsync/. A single `*` does not cross directory levels.
+      include: "*/application.yaml"
+      # argocd is bootstrapped via Helm and manages itself.
+      exclude: "argocd/application.yaml"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  revisionHistoryLimit: 3
+  syncPolicy:
+    automated: {}
+    syncOptions:
+      - ServerSideApply=true

--- a/packages/catalog/src/core.ts
+++ b/packages/catalog/src/core.ts
@@ -56,8 +56,11 @@ export async function buildCatalog(options: CliOptions, logger: CatalogLogger): 
 
   const markdown = renderCatalog(sections);
 
+  const totalApps = sections.reduce((sum, s) => sum + s.entries.length, 0);
+  const statsText = `${totalApps} self-hosted apps across ${sections.length} categories`;
+
   try {
-    await injectCatalog(markdown, readmePath, options, logger);
+    await injectCatalog(markdown, readmePath, options, logger, statsText);
   } catch (err) {
     logger.error(`Failed to write README.md — ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/packages/catalog/src/inject.test.ts
+++ b/packages/catalog/src/inject.test.ts
@@ -6,6 +6,11 @@ vi.mock("prettier", () => ({
   format: vi.fn().mockImplementation(async (content: string) => content),
 }));
 
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
 const BLOCK = "### Media\n\n| App | Description | Source Code |\n| --- | --- | --- |";
 
 const readmeWithMarkers = `# My Project
@@ -73,7 +78,6 @@ describe("injectCatalog", () => {
   });
 
   it("logs an error when markers are missing", async () => {
-    vi.mock("node:fs/promises", () => ({ readFile: vi.fn(), writeFile: vi.fn() }));
     const { readFile } = await import("node:fs/promises");
     vi.mocked(readFile).mockResolvedValue(readmeWithoutMarkers as never);
 
@@ -83,7 +87,6 @@ describe("injectCatalog", () => {
   });
 
   it("--check: logs error when README would change", async () => {
-    vi.mock("node:fs/promises", () => ({ readFile: vi.fn(), writeFile: vi.fn() }));
     const { readFile } = await import("node:fs/promises");
     vi.mocked(readFile).mockResolvedValue(readmeWithMarkers as never);
 
@@ -93,7 +96,6 @@ describe("injectCatalog", () => {
   });
 
   it("--check: no error when README is already up to date", async () => {
-    vi.mock("node:fs/promises", () => ({ readFile: vi.fn(), writeFile: vi.fn() }));
     const { readFile } = await import("node:fs/promises");
     const upToDate = buildUpdatedReadme(readmeWithMarkers, BLOCK);
     vi.mocked(readFile).mockResolvedValue(upToDate as never);
@@ -103,7 +105,6 @@ describe("injectCatalog", () => {
   });
 
   it("--dry-run: does not call writeFile", async () => {
-    vi.mock("node:fs/promises", () => ({ readFile: vi.fn(), writeFile: vi.fn() }));
     const { readFile, writeFile } = await import("node:fs/promises");
     vi.mocked(readFile).mockResolvedValue(readmeWithMarkers as never);
 
@@ -112,7 +113,6 @@ describe("injectCatalog", () => {
   });
 
   it("normal mode: calls writeFile with updated content", async () => {
-    vi.mock("node:fs/promises", () => ({ readFile: vi.fn(), writeFile: vi.fn() }));
     const { readFile, writeFile } = await import("node:fs/promises");
     vi.mocked(readFile).mockResolvedValue(readmeWithMarkers as never);
     vi.mocked(writeFile).mockResolvedValue(undefined);

--- a/packages/catalog/src/inject.test.ts
+++ b/packages/catalog/src/inject.test.ts
@@ -1,4 +1,4 @@
-import { buildUpdatedReadme, contentWouldChange, injectCatalog } from "./inject";
+import { buildUpdatedReadme, buildUpdatedStats, contentWouldChange, injectCatalog } from "./inject";
 import { CatalogLogger } from "./logger";
 
 vi.mock("prettier", () => ({
@@ -34,6 +34,23 @@ describe("buildUpdatedReadme", () => {
     const result = buildUpdatedReadme(readmeWithMarkers, BLOCK);
     expect(result).toContain("# My Project");
     expect(result).toContain("Footer text.");
+  });
+});
+
+describe("buildUpdatedStats", () => {
+  const readmeWithStats = "Runs **<!-- stats:start -->old count<!-- stats:end -->** today.\n";
+
+  it("replaces the inline text between the stats markers", () => {
+    const result = buildUpdatedStats(readmeWithStats, "31 apps across 7 categories");
+    expect(result).toContain(
+      "**<!-- stats:start -->31 apps across 7 categories<!-- stats:end -->**",
+    );
+    expect(result).not.toContain("old count");
+  });
+
+  it("is a no-op when the stats markers are absent", () => {
+    const noMarkers = "No stats markers here.\n";
+    expect(buildUpdatedStats(noMarkers, "31 apps across 7 categories")).toBe(noMarkers);
   });
 });
 

--- a/packages/catalog/src/inject.test.ts
+++ b/packages/catalog/src/inject.test.ts
@@ -42,10 +42,9 @@ describe("buildUpdatedStats", () => {
 
   it("replaces the inline text between the stats markers", () => {
     const result = buildUpdatedStats(readmeWithStats, "31 apps across 7 categories");
-    expect(result).toContain(
-      "**<!-- stats:start -->31 apps across 7 categories<!-- stats:end -->**",
+    expect(result).toBe(
+      "Runs **<!-- stats:start -->31 apps across 7 categories<!-- stats:end -->** today.\n",
     );
-    expect(result).not.toContain("old count");
   });
 
   it("is a no-op when the stats markers are absent", () => {

--- a/packages/catalog/src/inject.ts
+++ b/packages/catalog/src/inject.ts
@@ -12,8 +12,18 @@ const MARKER_START = "<!-- apps:start -->";
 const MARKER_END = "<!-- apps:end -->";
 const BLOCK_PATTERN = new RegExp(`(${MARKER_START})([\\s\\S]*?)(${MARKER_END})`, "m");
 
+const STATS_START = "<!-- stats:start -->";
+const STATS_END = "<!-- stats:end -->";
+const STATS_PATTERN = new RegExp(`(${STATS_START})([\\s\\S]*?)(${STATS_END})`, "m");
+
 export function buildUpdatedReadme(original: string, newBlock: string): string {
   return original.replace(BLOCK_PATTERN, (_match, p1, _p2, p3) => `${p1}\n\n${newBlock}\n\n${p3}`);
+}
+
+// Replaces the inline text between the stats markers. No-op when the markers are
+// absent, so the stats line stays optional.
+export function buildUpdatedStats(original: string, statsText: string): string {
+  return original.replace(STATS_PATTERN, (_match, p1, _p2, p3) => `${p1}${statsText}${p3}`);
 }
 
 export function contentWouldChange(original: string, newBlock: string): boolean {
@@ -25,6 +35,7 @@ export async function injectCatalog(
   readmePath: string,
   options: Pick<CliOptions, "check" | "dryRun">,
   logger: CatalogLogger,
+  statsText?: string,
 ): Promise<void> {
   const original = await readFile(readmePath, "utf-8");
 
@@ -33,7 +44,9 @@ export async function injectCatalog(
     return;
   }
 
-  const updated = await formatMarkdown(buildUpdatedReadme(original, newBlock), readmePath);
+  const withCatalog = buildUpdatedReadme(original, newBlock);
+  const withStats = statsText ? buildUpdatedStats(withCatalog, statsText) : withCatalog;
+  const updated = await formatMarkdown(withStats, readmePath);
 
   if (options.check) {
     if (updated !== original) {


### PR DESCRIPTION
### Summary

Started as a README readability pass and grew to include a real GitOps improvement: system apps are now deployed **in order** by ArgoCD instead of relying on a documented manual sequence.

**App-of-apps ordering (the functional change)**

- Adds `bootstrap/system.yaml`, a root **app-of-apps** that discovers every `apps/system/*/application.yaml` and deploys them in [sync-wave](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/) order: metallb (1) → longhorn/traefik (2) → infisical-operator (3) → reloader (4).
- Enables `syncPolicy.automated` (no prune, no self-heal) on those apps so each wave becomes healthy before the next starts — the sync-waves were previously inert without a parent app to drive them. Workload apps stay manual-sync by default.
- argocd (bootstraps itself) and rancher (optional management UI) are excluded from the wave and deployed manually.
- Extends the kubeconform CI job to also validate `bootstrap/`.

**README / docs**

- Adds an **Overview** section (stack + scale), a **Mermaid architecture diagram**, and **CI + MIT badges**.
- The app/category count is generated by `npm run generate` (via `stats` markers), so it can't drift.
- Rewrites **System App Order** to describe the app-of-apps flow (renamed from **Deploy Order** to avoid confusion with **Deploying an App**).
- Fixes a broken `helm install <path>` example (apps install from the remote `app-template` chart, not a local one) and tightens wording throughout.
- Reconciles stale references left by #299 (cert-manager / local-path-provisioner removal) across the README, `CLAUDE.md`, and the argocd app's README (which also had a garbled heading and the old `charts/` path).

### Type

- [ ] New app
- [ ] App update (version bump / config change)
- [ ] Bug fix
- [x] Other